### PR TITLE
rally bench playbook was using old variables names

### DIFF
--- a/enos/ansible/roles/bench/tasks/rally.yml
+++ b/enos/ansible/roles/bench/tasks/rally.yml
@@ -1,18 +1,18 @@
 ---
 - name: Copy rally scenarios
-  copy: src={{ rally_scenario }} dest=/root/rally_home/ owner=655500
+  copy: src={{ bench.location }} dest=/root/rally_home/ owner=655500
 
 - name: debug
-  debug: msg="rally task start {{ rally_scenario | basename }} --task-args '{{ rally_scenario_args}}'"
+  debug: msg="rally task start {{ bench.location | basename }} --task-args '{{ bench.args }}'"
 
-- name: Run rally scenario
+- name: Run rally benchmark
   docker_container:
-    name: "{{ rally_scenario | to_uuid }}"
+    name: "{{ bench.location | to_uuid }}"
     image: rallyforge/rally
     state: started
     volumes:
       - /root/rally_home:/home/rally
-    command: rally task start {{ rally_scenario | basename }} --task-args '{{ rally_scenario_args }}'
+    command: rally task start {{ bench.location | basename }} --task-args '{{ bench.args }}'
   register: docker_output
 
 - debug: var=docker_output.ansible_facts.ansible_docker_container.Id

--- a/enos/enos.py
+++ b/enos/enos.py
@@ -341,7 +341,7 @@ def bench(env=None, **kwargs):
     workload_dir = kwargs["--workload"]
     with open(os.path.join(workload_dir, "run.yml")) as workload_f:
         workload = yaml.load(workload_f)
-        for nature, desc in workload.items():
+        for bench_type, desc in workload.items():
             scenarios = desc.get("scenarios", [])
             for scenario in scenarios:
                 # merging args 
@@ -357,9 +357,11 @@ def bench(env=None, **kwargs):
                     playbook_path = os.path.join(ANSIBLE_DIR, 'run-bench.yml')
                     inventory_path = os.path.join(SYMLINK_NAME, 'multinode')
                     # NOTE(msimonin) all the scenarios must reside on the workload directory
-                    env['config']['scenario_type'] = nature
-                    env['config']['scenario'] = os.path.abspath(os.path.join(workload_dir, scenario["file"]))
-                    env['config']['scenario_args'] = a
+                    env['config']['bench'] = {
+                        'type': bench_type,
+                        'location': os.path.abspath(os.path.join(workload_dir, scenario["file"])),
+                        'args': a
+                    }
                     run_ansible([playbook_path], inventory_path, env['config'])
     
 @enostask("""


### PR DESCRIPTION
Now a dict is passed to the dedicated playbook to encapsulate all
variables it needs. For instance, rally will be passed this dict :
```
{
  'type': type # only rally for now
  'location':'path to the scenario' ,
  'args': {
        'args1': value,
        ...
  }
}
```
This dict is know as 'bench' on ansible side.