### PR TITLE
check enable_{monitoring,rally} before backup

### DIFF
--- a/enos/ansible/roles/backup/tasks/main.yml
+++ b/enos/ansible/roles/backup/tasks/main.yml
@@ -1,9 +1,13 @@
 ---
 - include: "rally.yml"
-  when: inventory_hostname in groups['disco/rally']
+  when: 
+    - inventory_hostname in groups['disco/rally']
+    - enable_rally
 
 - include: "influx.yml"
-  when: inventory_hostname in groups['disco/influx']
+  when:
+    - inventory_hostname in groups['disco/influx']
+    - enable_monitoring
 
 - include: "logs.yml"
 


### PR DESCRIPTION
rally and influx were backuped respectively regardless the values of

* enable_rally
* enable_monitoring