### PR TITLE
Allow backup dir with default to the symlink dir

### DIFF
--- a/enos/ansible/group_vars/all.yml
+++ b/enos/ansible/group_vars/all.yml
@@ -12,8 +12,6 @@ rally_scenarios_list: "all-scenarios.txt.sample"
 rally_times: 1
 rally_concurrency: 1
 
-backup_dir: "{{ playbook_dir }}/../current"
-
 # list of available patchs
 # to enable one patch copy past its description
 # to your local config file and enable it

--- a/enos/enos.py
+++ b/enos/enos.py
@@ -29,7 +29,7 @@ from utils.constants import (SYMLINK_NAME, TEMPLATE_DIR, ANSIBLE_DIR,
                              GRAFANA_IP, NEUTRON_IP, NETWORK_IFACE,
                              EXTERNAL_IFACE, VERSION)
 from utils.extra import (run_ansible, generate_inventory,
-                         generate_kolla_files)
+                         generate_kolla_files, to_abs_path)
 from utils.enostask import enostask
 
 from datetime import datetime
@@ -365,14 +365,25 @@ def bench(env=None, **kwargs):
                     run_ansible([playbook_path], inventory_path, env['config'])
     
 @enostask("""
-usage: enos backup [-vv|-s|--silent]
+usage: enos backup [--backup_dir=BACKUP_DIR ] [-vv|-s|--silent]
 
 Backup the environment
 
 Options:
+  --backup_dir=BACKUP_DIR   Backup directory.
   -h --help                 Show this help message.
 """)
 def backup(env = None, **kwargs):
+    backup_dir = kwargs['--backup_dir']
+    if backup_dir is None:
+        backup_dir = SYMLINK_NAME
+
+    backup_dir = to_abs_path(backup_dir)
+    # create if necessary
+    if not os.path.isdir(backup_dir):
+        os.mkdir(backup_dir)
+    # update the env
+    env['config']['backup_dir'] = backup_dir
     playbook_path = os.path.join(ANSIBLE_DIR, 'backup.yml')
     inventory_path = os.path.join(SYMLINK_NAME, 'multinode')
     run_ansible([playbook_path], inventory_path, env['config'])

--- a/enos/utils/extra.py
+++ b/enos/utils/extra.py
@@ -185,3 +185,14 @@ def generate_kolla_files(config_vars, kolla_vars, directory):
                     admin_openrc_vars,
                     admin_openrc_path)
     logging.info("admin-openrc generated in %s" % (admin_openrc_path))
+
+def to_abs_path(path):
+    """
+    if set, path is considered relative to the current working directory
+    if not just fail
+    Note: this does not check the existence
+    """
+    if os.path.isabs(path):
+        return path
+    else:
+       return os.path.join(os.getcwd(), path) 


### PR DESCRIPTION
backup_dir is a variable that is passed in the environnment before
backuping any data.
This directory is created if it does not exist.
This directory can be specified through the command line :
```
python -m enos.enos backup --backup_dir=BACKUP_DIR
```
if BACKUP_DIR isn't an absolute path it is considered relative to the
current working directory (directory where the command is called)
if BACKUP_DIR is not specified it is defaulted to the SYMLINK_NAME.

fix #15