### PR TITLE
fix tenant networks and public network

### DIFF
--- a/enos/enos.py
+++ b/enos/enos.py
@@ -36,16 +36,8 @@ from datetime import datetime
 import logging
 
 from docopt import docopt
-import requests
 import pprint
 from operator import itemgetter, attrgetter
-
-from keystoneauth1.identity import v3
-from keystoneauth1 import session
-from glanceclient import client as gclient
-from keystoneclient.v3 import client as kclient
-from novaclient import client as nclient
-from neutronclient.neutron import client as ntnclient
 
 import os
 import sys
@@ -220,75 +212,21 @@ Options:
   -h --help            Show this help message.
 """)
 def init_os(env=None, **kwargs):
-    def create_network(neutron, network):
-        """ Note: This isn't idempotent"""
-        network_id = ''
-        networks = neutron.list_networks()['networks']
-        print(networks)
-        if network['name'] not in map(itemgetter('name'), networks):
-            res = neutron.create_network({'network': network})
-            print(res)
-            network_id = res['network']['id']
-            logging.info("%s network has been created on OpenStack" % network['name'])
-
-        if not network_id:
-            logging.error("no network_id for %s network" % network['name'])
-            sys.exit(32)
-        return network_id
-
-    def create_subnet(neutron, subnet):
-        """ Note: This isn't idempotent"""
-        subnets = neutron.list_subnets()['subnets']
-        if subnet['name'] not in map(itemgetter('name'), subnets):
-            s = neutron.create_subnet({'subnet': subnet})
-            logging.info("%s has been created on OpenStack" % subnet['name'])
-            return s['subnet']['id']
-        else:
-            sys.exit(32)
-
-
     logging.debug('phase[init]: args=%s' % kwargs)
-    # Authenticate to keystone
-    # http://docs.openstack.org/developer/keystoneauth/using-sessions.html
-    # http://docs.openstack.org/developer/python-glanceclient/apiv2.html
-    keystone_addr = env['config']['vip']
+    cmd = ['source %s' % os.path.join(SYMLINK_NAME, 'admin-openrc')]
+    # add cirros image
+    images = [{'name': 'cirros.uec', 'url':'http://download.cirros-cloud.net/0.3.4/cirros-0.3.4-x86_64-disk.img'}] 
+    for image in images:
+        cmd.append("/usr/bin/wget -q -O /tmp/%s %s" % (image['name'], image['url']))
+        cmd.append('openstack image create' \
+                ' --disk-format=qcow2' \
+                ' --container-format=bare' \
+                ' --property architecture=x86_64' \
+                ' --file /tmp/%s' \
+                ' %s' % (image['name'], image['name']))
 
-    auth = v3.Password(auth_url='http://%s:5000/v3' % keystone_addr,
-                       username='admin',
-                       password='demo',
-                       project_name='admin',
-                       user_domain_id='default',
-                       project_domain_id='default')
-    sess = session.Session(auth=auth)
-
-    # Install `member` role
-    keystone = kclient.Client(session=sess)
-    role_name = 'member'
-    if role_name not in map(attrgetter('name'), keystone.roles.list()):
-        logging.info("Creating role %s" % role_name)
-        keystone.roles.create(role_name)
-
-    # Install cirros with glance client if absent
-    glance = gclient.Client('2', session=sess)
-    cirros_name = 'cirros.uec'
-    if cirros_name not in map(itemgetter('name'), glance.images.list()):
-        # Download cirros
-        image_url = 'http://download.cirros-cloud.net/0.3.4/'
-        image_name = 'cirros-0.3.4-x86_64-disk.img'
-        logging.info("Downloading %s at %s..." % (cirros_name, image_url))
-        cirros_img = requests.get(image_url + '/' + image_name)
-
-        # Install cirros
-        cirros = glance.images.create(name=cirros_name,
-                                      container_format='bare',
-                                      disk_format='qcow2',
-                                      visibility='public')
-        glance.images.upload(cirros.id, cirros_img.content)
-        logging.info("%s has been created on OpenStack" % cirros_name)
-
-    # Install default flavors
-    nova = nclient.Client('2', session=sess)
-    default_flavors = [
+    # flavors
+    flavors = [
             # name, ram, disk, vcpus
             ('m1.tiny', 512, 1, 1),
             ('m1.small', 2048, 20, 1),
@@ -296,58 +234,70 @@ def init_os(env=None, **kwargs):
             ('m1.large', 8192, 80, 4),
             ('m1.xlarge', 16384, 160, 8)
     ]
-    current_flavors = map(attrgetter('name'), nova.flavors.list())
-    for flavor in default_flavors:
-        if flavor[0] not in current_flavors:
-            nova.flavors.create(name=flavor[0],
-                        ram=flavor[1],
-                        disk=flavor[2],
-                        vcpus=flavor[3])
-            logging.info("%s has been created on OpenStack" % flavor[0])
+    for flavor in flavors:
+        cmd.append('openstack flavor create %s' \
+                ' --id auto' \
+                ' --ram %s' \
+                ' --disk %s' \
+                ' --vcpus %s' \
+                ' --public' % (flavor[0], flavor[1], flavor[2], flavor[3]))
 
-    # Install default network
-    neutron = ntnclient.Client('2', session=sess)
-    public_network_id = create_network(neutron, {
-        'name': 'public',
-        'provider:network_type': 'flat',
-        'provider:physical_network': 'physnet1',
-        'router:external': True
-    })
-    public_subnet_id = create_subnet(neutron, {
-        'name': 'public_subnet',
-        'network_id': public_network_id,
-        'enable_dhcp': False,
-        'allocation_pools': [{
-            'start': env['provider_network']['start'],
-            'end': env['provider_network']['end']
-         }],
-        'cidr': env['provider_network']['cidr'],
-        'gateway_ip': env['provider_network']['gateway'],
-        'ip_version': 4
-    })
-    private_network_id = create_network(neutron, {
-        'name': 'private',
-        'provider:network_type': 'vxlan'
-    })
-    private_subnet_id = create_subnet(neutron, {
-        'name': 'private_subnet',
-        'network_id': private_network_id,
-        'cidr': '192.168.0.0/24',
-        'gateway_ip': '192.168.0.1',
-        'dns_nameservers': [env['provider_network']['dns']],
-        'ip_version': 4
-    })
-    router = neutron.create_router({
-        'router': {
-            'name': 'router'
-            }
-    })
-    neutron.add_interface_router(router["router"]["id"], {
-        "subnet_id": private_subnet_id
-    })
-    neutron.add_gateway_router(router["router"]["id"], {
-        "network_id": public_network_id
-    })
+    # security groups - allow everything 
+    protos = ['icmp', 'tcp', 'udp']
+    for proto in protos:
+        cmd.append('openstack security group rule create default' \
+                ' --protocol %s' \
+                ' --dst-port 1:65535' \
+                ' --src-ip 0.0.0.0/0' % proto)
+    
+    # quotas - set some unlimited for admin project
+    quotas = ['cores', 'ram', 'instances']
+    for quota in quotas:
+        cmd.append('nova quota-class-update --%s -1 default' % quota)
+
+    quotas = ['fixed-ips', 'floating-ips']
+    for quota in quotas:
+        cmd.append('openstack quota set --%s -1 admin' % quota)
+
+    # default network (one public / one provite)
+    cmd.append('openstack network create public' \
+            ' --share' \
+            ' --provider-physical-network physnet1' \
+            ' --provider-network-type flat' \
+            ' --external')
+    cmd.append('openstack subnet create public-subnet' \
+            ' --network public' \
+            ' --subnet-range %s' \
+            ' --no-dhcp'
+            ' --allocation-pool start=%s,end=%s' \
+            ' --gateway %s' \
+            ' --ip-version 4' % (
+                env["provider_network"]['cidr'],
+                env["provider_network"]['start'],
+                env["provider_network"]['end'],
+                env["provider_network"]['gateway'])
+            )
+    cmd.append('openstack network create private' \
+            ' --provider-network-type vxlan')
+
+    cmd.append('openstack subnet create private-subnet' \
+            ' --network private' \
+            ' --subnet-range 192.168.0.0/18' \
+            ' --gateway 192.168.0.1' \
+            ' --dns-nameserver %s' \
+            ' --ip-version 4' % (
+                env["provider_network"]['dns'])
+            )
+    # create a router between this two networks
+    cmd.append('openstack router create router')
+    # NOTE(msimonin): not sure how to handle these 2 with openstack cli 
+    cmd.append('neutron router-gateway-set router public')
+    cmd.append('neutron router-interface-add router private-subnet')
+
+    cmd = '\n'.join(cmd)
+    print(cmd)
+    call(cmd, shell = True)
+
 
 @enostask("""
 usage: enos bench [--workload=WORKLOAD]

--- a/enos/provider/g5k.py
+++ b/enos/provider/g5k.py
@@ -413,7 +413,7 @@ class G5K(Provider):
 
     def _get_free_ip(self, count):
         """
-        Gets free ips an a provider network information used to create a
+        Gets free ips and a provider network information used to create a
         flat network external network during the init phase.
         Originally it was done by reserving a subnet
         we now moves this implementation to a vlan based implementation

--- a/enos/provider/g5k.py
+++ b/enos/provider/g5k.py
@@ -11,6 +11,7 @@ import sys
 # from execo import configuration
 import execo as EX
 import execo_g5k as EX5
+from execo_g5k import api_utils as api
 from execo_g5k.api_utils import get_cluster_site
 from execo_g5k import OarSubmission
 
@@ -72,17 +73,30 @@ class G5K(Provider):
         # docker registry
         # influx db
         # grafana
-        vip_addresses = self._get_free_ip(5)
+        vip_addresses, provider_network = self._get_free_ip(5)
         # Get the NIC devices of the reserved cluster
         # XXX: this only works if all nodes are on the same cluster,
         # or if nodes from different clusters have the same devices
         interfaces = self._get_cluster_nics(self.config['resources'].keys()[0])
+
+
         network_interface = str(interfaces[0])
         external_interface = None
 
         if len(interfaces) > 1:
             external_interface = str(interfaces[1])
+            site, vlan = self._get_primary_vlan()
+            # NOTE(msimonin) deployed is composed of the list of hostnames
+            # unmodified with the vlan. This is required by set_nodes_vlan.
+            api.set_nodes_vlan(site, map(lambda d: EX.Host(d), deployed), external_interface, vlan)
+
+            self._exec_command_on_nodes(
+                self.deployed_nodes,
+                'ifconfig %s up && dhclient -nw %s' % (external_interface, external_interface),
+                'mounting secondary interface'
+             )
         else:
+            # TODO(msimonin) fix the network in this case as well.
             external_interface = 'veth0'
             logging.warning("%s has only one NIC. The same interface "
                            "will be used for network_interface and "
@@ -102,7 +116,8 @@ class G5K(Provider):
 
         return (roles,
                 map(str, vip_addresses),
-                [network_interface, external_interface])
+                [network_interface, external_interface],
+                provider_network)
 
     def before_preintsall(self, env):
         # Create a virtual interface for veth0 (if any)
@@ -398,7 +413,8 @@ class G5K(Provider):
 
     def _get_free_ip(self, count):
         """
-        Gets a free ip.
+        Gets free ips an a provider network information used to create a
+        flat network external network during the init phase.
         Originally it was done by reserving a subnet
         we now moves this implementation to a vlan based implementation
 
@@ -413,14 +429,25 @@ class G5K(Provider):
         # the last ip is reserved x.x.x.255, the previous one also
         # x.x.x..254 (gw), the x.x.x.253 seems to be pingable as well
         # (seems undocumented in g5k wiki)
-        return list(range_ips[-3 - count:-3])
+        reserved = 3 
+        start_index = -3-count-1024
+        end_index = -3-count-1
+        provider_network = {
+                'cidr': str(cidr),
+                'start': str(range_ips[start_index]),
+                'end': str(range_ips[end_index]),
+                'gateway': str(range_ips[-2]), 
+                'dns': '131.254.203.235'
+        }
+        return list(range_ips[end_index+1:-reserved]), provider_network
+
 
     def _get_cluster_nics(self, cluster):
         site = EX5.get_cluster_site(cluster)
         nics = EX5.get_resource_attributes(
             '/sites/%s/clusters/%s/nodes'
             % (site, cluster))['items'][0]['network_adapters']
-        return [nic['device'] for nic in nics if nic['mountable']]
+        return [nic['device'] for nic in nics if nic['mountable'] and nic['interface'] == 'Ethernet' ]
 
     def _exec_command_on_nodes(self, nodes, cmd, label, conn_params=None):
         """Execute a command on a node (id or hostname) or on a set of nodes"""

--- a/enos/provider/provider.py
+++ b/enos/provider/provider.py
@@ -11,8 +11,8 @@ class Provider:
 
         The `config` parameter contains the client request (eg, number
         of compute per role among other things). This method returns a
-        list of the form [{Role: [Host]}] and a pool of 5 ips.
-
+        list of the form [{Role: [Host]}], a pool of 5 ips, and a usable
+        provider external network.
         """
         pass
 

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,6 @@ setup(
         'execo==2.6.1',
         'ansible==2.1.2',
         'docopt==0.6.2',
-        'requests==2.11.0',
         'httplib2==0.9.2',
         'python-dateutil==2.2',
         'python-glanceclient==2.3.0',


### PR DESCRIPTION
Networks weren't well configured. VMs didn't have access to internet 
floating ips were not routable on g5k. (actually they didn't exit at
all).
* Initialize a public flat provider network with a range of ips
that maps ips from the vlans.  Set gateway and dns accordingly.
* Initialize a private network.
VMs booted in the private should access internet, floating ips should
be attachable and routed on G5K (beware of security groups).

This commit fix only the case where two NICs are available.