### PR TITLE
Network emulation (latency and bandwidth constraints)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,12 @@
 ## Synopsis
 
 This script deploys an OpenStack on Grid'5000 using
-[Kolla](https://wiki.openstack.org/wiki/Kolla) and allows easy
-customization of the system (change in the default topology,
-configuration parameters) and reproducible experiments.
+[Kolla](https://wiki.openstack.org/wiki/Kolla) and targets reproducible
+experiments and allows easy :
+
+* [customization of the system](#examples-of-customization)
+* [benchmarking](#launch-a-workload)
+* [visualization of various metrics](#post-mortem-analysis)
 
 ## Installation
 
@@ -215,6 +218,17 @@ code to enable custom configuration files to be used (and by extension
 custom kolla code). See the possible patch declaration in
 `ansible/group_vars/all.yml`. Patches should be added in the
 configuration file of the experiment.
+
+### Adding network constraints
+
+Network constraints (latency/bandwidth limitations) are enabled by the use of groups of nodes. Resources *must* be described using a `topology` description instead of a `resources` description. An example of such a definition is given in the file `reservation.yaml.topology.sample`.
+
+To enforce the constraints, you can invoke :
+```
+python -m enos.enos tc
+```
+
+> The machines must be available, thus the `up` phase must have been called before.
 
 ## Known limitations
 

--- a/enos/ansible/group_vars/all.yml
+++ b/enos/ansible/group_vars/all.yml
@@ -5,6 +5,11 @@ g5k_role: unknown
 
 enable_monitoring: true
 
+# enable tc constraints when invoking tc phase
+tc_enable: true
+# output dir to store test validation of tc rules enforcement 
+tc_output_dir: /tmp
+
 # default openstack env
 os_env:
   OS_PROJECT_DOMAIN_ID: default

--- a/enos/ansible/roles/utils/tasks/ips.yml
+++ b/enos/ansible/roles/utils/tasks/ips.yml
@@ -1,0 +1,7 @@
+---
+- name: dumping all ips in a file
+  template:
+    src: ips.txt.j2
+    dest: "{{ ips_file }}"
+  delegate_to: localhost
+  run_once: true

--- a/enos/ansible/roles/utils/tasks/main.yml
+++ b/enos/ansible/roles/utils/tasks/main.yml
@@ -1,0 +1,2 @@
+---
+- include: "{{ action }}.yml"

--- a/enos/ansible/roles/utils/tasks/tc.yml
+++ b/enos/ansible/roles/utils/tasks/tc.yml
@@ -1,21 +1,24 @@
 ---
-- name: Removing root qdisc for {{ network_interface }}
-  shell: "tc qdisc del dev {{ network_interface }} root || true"
+# Resetting network constraints
+- name: Removing root qdisc for {{ item.device }}
+  shell: "tc qdisc del dev {{ item.device }} root || true"
+  with_items: "{{ ips_with_constraints[inventory_hostname].devices }}"
+  when:
+    - item.active
+    - item.type == "ether"
 
-- name: Removing root qdisc for {{ neutron_external_interface }}
-  shell: "tc qdisc del dev {{ neutron_external_interface }} root || true"
+- name: Preparing htf for {{ item.device }}
+  shell: "tc qdisc add dev {{ item.device }} root handle 1: htb"
+  with_items: "{{ ips_with_constraints[inventory_hostname].devices }}"
+  when:
+    - tc_enable
+    - item.active
+    - item.type == "ether"
 
-- name: Preparing htf for {{ network_interface }}
-  shell: "tc qdisc add dev {{ network_interface }} root handle 1: htb"
-  when: tc_enable
-
-- name: Preparing htf for {{ neutron_external_interface }}
-  shell: "tc qdisc add dev {{ neutron_external_interface }} root handle 1: htb"
-  when: tc_enable
 
 - name: Add rate limit
   command: "tc class add dev {{ item.1.device }} parent 1: classid 1:{{ item.0 + 1 }} htb rate {{ item.1.rate }}"
-  with_indexed_items: "{{ tc }}"
+  with_indexed_items: "{{ ips_with_constraints[inventory_hostname].tc }}"
   when:
     - tc_enable
     - item[1].source == ansible_nodename 
@@ -23,7 +26,8 @@
 
 - name: Adding delay
   command: "tc qdisc add dev {{ item.1.device }} parent 1:{{ item.0 + 1 }} handle {{ item.0 + 10 }}: netem delay {{ item.1.delay }}"
-  with_indexed_items: "{{ tc }}"
+  with_indexed_items: "{{ ips_with_constraints[inventory_hostname].tc }}"
+
   when:
     - tc_enable
     - item[1].source == ansible_nodename
@@ -31,7 +35,7 @@
 
 - name: Adding filter
   command: "tc filter add dev {{ item.1.device }} parent 1: protocol ip  u32 match ip dst {{ item.1.target }} flowid 1:{{ item.0 + 1 }}"
-  with_indexed_items: "{{ tc }}"
+  with_indexed_items: "{{ ips_with_constraints[inventory_hostname].tc }}"
   when:
     - tc_enable
     - item[1].source == ansible_nodename

--- a/enos/ansible/roles/utils/tasks/tc.yml
+++ b/enos/ansible/roles/utils/tasks/tc.yml
@@ -1,0 +1,38 @@
+---
+- name: Removing root qdisc for {{ network_interface }}
+  shell: "tc qdisc del dev {{ network_interface }} root || true"
+
+- name: Removing root qdisc for {{ neutron_external_interface }}
+  shell: "tc qdisc del dev {{ neutron_external_interface }} root || true"
+
+- name: Preparing htf for {{ network_interface }}
+  shell: "tc qdisc add dev {{ network_interface }} root handle 1: htb"
+  when: tc_enable
+
+- name: Preparing htf for {{ neutron_external_interface }}
+  shell: "tc qdisc add dev {{ neutron_external_interface }} root handle 1: htb"
+  when: tc_enable
+
+- name: Add rate limit
+  command: "tc class add dev {{ item.1.device }} parent 1: classid 1:{{ item.0 + 1 }} htb rate {{ item.1.rate }}"
+  with_indexed_items: "{{ tc }}"
+  when:
+    - tc_enable
+    - item[1].source == ansible_nodename 
+
+
+- name: Adding delay
+  command: "tc qdisc add dev {{ item.1.device }} parent 1:{{ item.0 + 1 }} handle {{ item.0 + 10 }}: netem delay {{ item.1.delay }}"
+  with_indexed_items: "{{ tc }}"
+  when:
+    - tc_enable
+    - item[1].source == ansible_nodename
+
+
+- name: Adding filter
+  command: "tc filter add dev {{ item.1.device }} parent 1: protocol ip  u32 match ip dst {{ item.1.target }} flowid 1:{{ item.0 + 1 }}"
+  with_indexed_items: "{{ tc }}"
+  when:
+    - tc_enable
+    - item[1].source == ansible_nodename
+

--- a/enos/ansible/roles/utils/tasks/test.yml
+++ b/enos/ansible/roles/utils/tasks/test.yml
@@ -1,0 +1,43 @@
+---
+- name: Adding flent repository
+  apt_repository:
+    repo: deb http://download.opensuse.org/repositories/home:/tohojo:/flent/xUbuntu_14.04/ /
+    state: present
+
+- name: Installing flent
+  apt:
+    name: flent
+    allow_unauthenticated: yes
+    update_cache: true
+
+- name: Installing fping
+  apt: 
+   name: fping
+   update_cache: true
+
+- name: Uploading the host list
+  template: 
+    src: hosts.txt.j2
+    dest: /tmp/hosts
+
+- name: Get the latencies between all the nodes
+  shell: "fping -C 5 -q -s -e -f /tmp/hosts 2>/tmp/result"
+
+- name: Fetching the results
+  fetch:
+    src: /tmp/result
+    dest: "/{{ tc_output_dir }}/{{ inventory_hostname }}.out"
+    flat: yes
+
+- name: Running flent (tcp_upload)
+  shell: "flent tcp_upload -l 5 -H {{ hostvars[item]['ansible_default_ipv4']['address']   }} -f stats -o /tmp/tcp_upload_{{ inventory_hostname }}_{{ item  }}.stats || true 2>/dev/null"
+  when: inventory_hostname == groups.all[0]
+  with_items: "{{ groups.all }}"
+
+- name: Fetching the results
+  fetch:
+    src: "/tmp/tcp_upload_{{ inventory_hostname }}_{{ item  }}.stats"
+    dest: "{{ tc_output_dir }}/tcp_upload_{{ inventory_hostname }}_{{ item  }}.stats"
+    flat: yes
+  when: inventory_hostname == groups.all[0]
+  with_items: "{{ groups.all }}"

--- a/enos/ansible/roles/utils/tasks/test.yml
+++ b/enos/ansible/roles/utils/tasks/test.yml
@@ -1,7 +1,7 @@
 ---
 - name: Adding flent repository
   apt_repository:
-    repo: deb http://download.opensuse.org/repositories/home:/tohojo:/flent/xUbuntu_14.04/ /
+    repo: deb http://download.opensuse.org/repositories/home:/tohojo:/flent/Debian_8.0/ /
     state: present
 
 - name: Installing flent

--- a/enos/ansible/roles/utils/templates/hosts.txt.j2
+++ b/enos/ansible/roles/utils/templates/hosts.txt.j2
@@ -1,0 +1,3 @@
+{% for host in groups['all'] %}
+ {{ hostvars[host]['ansible_eth0']['ipv4']['address'] }}
+{% endfor %}

--- a/enos/ansible/roles/utils/templates/ips.txt.j2
+++ b/enos/ansible/roles/utils/templates/ips.txt.j2
@@ -1,0 +1,11 @@
+---
+{% for host in groups['all'] %}
+{{host}}:
+  all_ipv4_addresses: 
+    {{hostvars[host]['ansible_all_ipv4_addresses'] | to_nice_yaml(2) | indent(width=4, indentfirst=false)}}
+  devices:
+    -
+      {{ hostvars[host]['ansible_' + network_interface] | to_nice_yaml(2) | indent(width=6, indentfirst=false)}}
+    - 
+      {{ hostvars[host]['ansible_' + neutron_external_interface] | to_nice_yaml(2) | indent(width=6, indentfirst=false)}}
+{% endfor %}

--- a/enos/ansible/utils.yml
+++ b/enos/ansible/utils.yml
@@ -1,0 +1,11 @@
+---
+- name: Collector
+  hosts: all
+  tasks: []
+
+- name: Utils
+  hosts: all
+  roles:
+    - { role: utils,
+        tags: ['utils'],
+      }

--- a/enos/enos.py
+++ b/enos/enos.py
@@ -49,7 +49,6 @@ from subprocess import call
 import yaml
 import json
 import itertools
-import re
 
 CALL_PATH = os.getcwd()
 

--- a/enos/enos.py
+++ b/enos/enos.py
@@ -17,6 +17,7 @@ Commands:
   bench          Run rally on this OpenStack.
   backup         Backup the environment
   ssh-tunnel     Print configuration for port forwarding with horizon.
+  tc             Enforce network constraints
   info           Show information of the actual deployment.
   deploy         Shortcut for enos up, then enos os and enos config.
 
@@ -30,6 +31,8 @@ from utils.constants import (SYMLINK_NAME, TEMPLATE_DIR, ANSIBLE_DIR,
                              EXTERNAL_IFACE, VERSION)
 from utils.extra import (run_ansible, generate_inventory,
                          generate_kolla_files, to_abs_path)
+
+from utils.network_constraints import build_grp_constraints, build_ip_constraints
 from utils.enostask import enostask
 
 from datetime import datetime
@@ -46,6 +49,7 @@ from subprocess import call
 import yaml
 import json
 import itertools
+import re
 
 CALL_PATH = os.getcwd()
 
@@ -86,7 +90,6 @@ def up(provider=None, env=None, **kwargs):
     env['ips'] = ips
     env['eths'] = eths
     env['provider_network'] = provider_network
-
     # Generates a directory for results
     resultdir_name = 'enos_' + datetime.today().isoformat()
     resultdir = os.path.join(CALL_PATH, resultdir_name)
@@ -409,6 +412,67 @@ def ssh_tunnel(env=None, **kwargs):
     logging.info(script)
     logging.info("___")
 
+@enostask("""
+usage: enos tc [--test] [-vv|-s|--silent]
+
+Enforce network constraints
+
+Options:
+  --test   Test the rules by generating various reports
+  -h --help                 Show this help message.
+""")
+def tc(provider=None, env=None, **kwargs):
+    """
+    Enforce network constraints
+    1) Retrieve the list of ips for all nodes (ansible)
+    2) Build all the constraints (python)
+        {source:src, target: ip_dest, device: if, rate:x,  delay:y}
+    3) Enforce those constraints (ansible)
+    """
+    test = kwargs['--test']
+    if test:
+        logging.info('Checking the constraints')
+        utils_playbook = os.path.join(ANSIBLE_DIR, 'utils.yml')
+        env['config'].update({'action': 'test'})
+        run_ansible([utils_playbook], env['inventory'], env['config'])
+        return
+
+    # 1. getting  ips/devices information
+    logging.info('Getting the ips of all nodes')
+    utils_playbook = os.path.join(ANSIBLE_DIR, 'utils.yml')
+    ips_file = os.path.join(env['resultdir'], 'ips.txt')
+    env['config'].update({'action': 'ips', 'ips_file': ips_file})
+    run_ansible([utils_playbook], env['inventory'], env['config'])
+    
+    # 2.a building the group constraints
+    logging.info('Building all the constraints')
+    topology = env['config']['topology']
+    network_constraints = env['config']['network_constraints']
+    constraints = build_grp_constraints(topology, network_constraints)
+    # 2.b Building the ip/device level constaints
+    ip_constraints = []
+    with open(ips_file) as f:
+        ips = yaml.load(f)
+        # will hold every single constraint 
+        ip_constraints = build_ip_constraints(env['rsc'], ips, constraints)
+        # dumping it for debugging purpose
+        generated_constraint_file = os.path.join(env['resultdir'], 'generated_constraints.yml')
+        with open(generated_constraint_file, 'w') as g:
+            yaml.dump(ip_constraints, g)
+    
+    # 3. Enforcing those constraints 
+    logging.info('Enforcing the constraints')
+    # enabling/disabling network constraints
+    enable = network_constraints['enable'] if 'enable' in network_constraints else True
+    utils_playbook = os.path.join(ANSIBLE_DIR, 'utils.yml')
+    env['config'].update({
+        'action': 'tc',
+        'tc': ip_constraints,
+        'tc_enable': enable,
+        'tc_output_dir': env['resultdir']
+    })
+    run_ansible([utils_playbook], env['inventory'], env['config'])
+    
 
 @enostask("usage: enos info")
 def info(env=None, **kwargs):
@@ -463,6 +527,8 @@ def main():
         backup(**docopt(backup.__doc__, argv=argv))
     elif args['<command>'] == 'ssh-tunnel':
         ssh_tunnel(**docopt(ssh_tunnel.__doc__, argv=argv))
+    elif args['<command>'] == 'tc':
+        tc(**docopt(tc.__doc__, argv=argv))
     elif args['<command>'] == 'info':
         info(**docopt(info.__doc__, argv=argv))
     else:

--- a/enos/provider/g5k.py
+++ b/enos/provider/g5k.py
@@ -410,21 +410,21 @@ class G5K(Provider):
             Distribute the nodes of pools according to the resources claim
             resources : 
                 cluster1: 
-                    role11: n11
-                    role12: n12
+                    control: 1
+                    compute: 2
                     ...
                 cluster2:
-                    role21: n21
-                    role22: n22
+                    compute: 3 
+
             pools:
-                cluster1: [node11, node12, ...]
-                cluster2: [node21, node22, ...]
+                cluster1: [n11, n12, n13]
+                cluster2: [n21, n22, n23]
 
             expected output
 
-            roles:
-                role'1: [node'11, node'12 ...]
-                role'2: [node'21, node'22 ...]
+            roles: (one possible distribution)
+                control: [n11]
+                compute: [n12, n13, n21, n22, n23]
             """
             roles_set = set()
             for roles in resources.values():
@@ -462,11 +462,12 @@ class G5K(Provider):
 
         # Extend roles with defined groups
         # Distribute nodes into groups
-        pools = mk_pools()
-        for group, resources in self.config['topology'].items():
-            grp_roles = mk_roles(pools, resources)
-            # flattening the resources in this case 
-            roles[group] = sum(grp_roles.values(), [])
+        if 'topology' in self.config:
+            pools = mk_pools()
+            for group, resources in self.config['topology'].items():
+                grp_roles = mk_roles(pools, resources)
+                # flattening the resources in this case 
+                roles[group] = sum(grp_roles.values(), [])
 
         logging.info("Roles: %s" % pf(roles))
         return roles

--- a/enos/utils/extra.py
+++ b/enos/utils/extra.py
@@ -12,6 +12,7 @@ import jinja2
 import os
 import yaml
 import logging
+import re
 
 # These roles are mandatory for the
 # the original inventory to be valid
@@ -196,3 +197,49 @@ def to_abs_path(path):
         return path
     else:
        return os.path.join(os.getcwd(), path) 
+
+def build_resources(topology):
+    """
+    Build the resource list
+    For now we are just aggregating all the resources
+    This could be part of a flat resource builder
+    """
+
+    def merge_add(cluster_roles, roles):
+        """ merge two dicts, sum the values"""
+        for role, nb in roles.items():
+            cluster_roles.setdefault(role, 0)
+            cluster_roles[role] = cluster_roles[role] + nb
+
+    resource = {}
+    for group, clusters in topology.items():
+        for cluster, roles in clusters.items():
+            resource.setdefault(cluster, {})
+            merge_add(resource[cluster], roles)
+    return resource
+
+def expand_groups(grp):
+    """
+    Expand group names.
+    e.g: 
+        * grp[1-3] -> [grp1, grp2, grp3]
+        * grp1 -> [grp1]
+    """
+    p = re.compile('(?P<name>\w+)\[(?P<start>\d+)-(?P<end>\d+)\]')
+    m = p.match(grp)
+    if m is not None:
+        s = int(m.group('start'))
+        e = int(m.group('end'))
+        n = m.group('name')
+        return map(lambda x: n + str(x), range(s, e + 1))
+    else:
+        return [grp]
+
+
+def expand_topology(topology):
+    expanded = {}
+    for grp, desc in topology.items():
+        grps = expand_groups(grp)
+        for g in grps:
+            expanded[g] = desc
+    return expanded

--- a/enos/utils/extra.py
+++ b/enos/utils/extra.py
@@ -225,7 +225,7 @@ def expand_groups(grp):
         * grp[1-3] -> [grp1, grp2, grp3]
         * grp1 -> [grp1]
     """
-    p = re.compile('(?P<name>\w+)\[(?P<start>\d+)-(?P<end>\d+)\]')
+    p = re.compile('(?P<name>.+)\[(?P<start>\d+)-(?P<end>\d+)\]')
     m = p.match(grp)
     if m is not None:
         s = int(m.group('start'))

--- a/enos/utils/network_constraints.py
+++ b/enos/utils/network_constraints.py
@@ -1,0 +1,128 @@
+from extra import expand_groups
+
+def expand_description(desc):
+    """
+    Expand the description given the group names/patterns
+    e.g:
+    {src: grp[1-3], dst: grp[4-6] ...} will generate 9 descriptions
+    """
+    srcs = expand_groups(desc['src'])
+    dsts = expand_groups(desc['dst'])
+    descs = []
+    for src in srcs:
+        for dst in dsts:
+            local_desc = desc.copy()
+            local_desc['src'] = src
+            local_desc['dst'] = dst
+            descs.append(local_desc)
+
+    return descs
+
+
+def same(g1, g2):
+    """
+    Two network constraints are equals if they have the same
+    sources and destinations
+    """
+    return g1['src'] == g2['src'] and g1['dst'] == g2['dst']
+
+def generate_default_grp_constraints(topology, network_constraints):
+    """
+    Generate default symetric grp constraints.
+    """
+    default_delay = network_constraints.get('default_delay')
+    default_rate = network_constraints.get('default_rate')
+    # expand each groups
+    grps = map(lambda g: expand_groups(g), topology.keys())
+    # flatten
+    grps = [x for expanded_group in grps for x in expanded_group]
+    # building the default group constraints
+    return [{ 
+        'src': grp1,
+        'dst': grp2,
+        'delay': default_delay,
+        'rate' : default_rate
+      } for grp1 in grps for grp2 in grps if grp1 != grp2]
+
+def generate_actual_grp_constraints(network_constraints):
+    """
+    Generate the user specified constraints
+    """
+    if 'constraints' not in network_constraints:
+        return []
+
+    default_delay = network_constraints.get('default_delay')
+    default_rate = network_constraints.get('default_rate')
+
+    constraints = network_constraints['constraints']
+    actual = []
+    for desc in constraints:
+        descs = expand_description(desc)
+        for desc in descs:
+            actual.append(desc)
+            if 'symetric' in desc:
+                sym = desc.copy()
+                sym['src'] = desc['dst']
+                sym['dst'] = desc['src']
+                actual.append(sym)
+    return actual
+
+def merge_constraints(constraints, actual):
+    """
+    Merge the constraints avoiding duplicates
+    Change constraints in place.
+    """
+    for a in actual:
+        i = 0
+        while i < len(constraints):
+            c  = constraints[i]
+            if same(a, c):
+                constraints[i].update(a)
+                break
+            i = i + 1
+
+
+def build_grp_constraints(topology, network_constraints):
+    """
+    Generate constraints at the group level, 
+    It expands the group names and deal with symetric constraints.
+    """
+    # generate defaults constraints
+    constraints = generate_default_grp_constraints(topology, network_constraints)
+    # Updating the constraints if necessary 
+    if 'constraints' in network_constraints:
+        actual = generate_actual_grp_constraints(network_constraints)
+        merge_constraints(constraints, actual)
+
+    return constraints
+
+def build_ip_constraints(rsc, ips, constraints):
+    """
+    Generate the constraints at the ip/device level.
+    Those constraints are those used by ansible to enforce tc/netem rules.
+    """
+    generated_constraints = []
+    for constraint in constraints:
+        gsrc = constraint['src']
+        gdst = constraint['dst']
+        gdelay = constraint['delay']
+        grate = constraint['rate']
+        for s in rsc[gsrc]:
+            # one possible source
+            sdevices = map(lambda x: x['device'], ips[s.address]['devices'])
+            for sdevice in sdevices:
+                # one possible device
+                for d in rsc[gdst]:
+                    # one possible destination
+                    dallips = ips[d.address]['all_ipv4_addresses']
+                    # Let's keep docker bridge out of this
+                    dallips = filter(lambda x: x != '172.17.0.1', dallips)
+                    for dip in dallips:
+                        generated_constraints.append({
+                            'source': s.address,
+                            'target': dip,
+                            'device': sdevice,
+                            'delay': gdelay,
+                            'rate' : grate
+                        })
+    return generated_constraints

--- a/reservation.yaml.topology.sample
+++ b/reservation.yaml.topology.sample
@@ -6,6 +6,11 @@
 name: discovery-kolla
 walltime: "06:00:00"
 
+# Define a set of groups
+# The `resources` description will be overwritten by the
+# `topology` description.
+# The notation grp[2-4] wil be expanded to create 3
+# groups
 topology:
   grp1:
     paravance: 
@@ -15,6 +20,8 @@ topology:
     paravance: 
       compute: 1
 
+# Define a set of constraints between groups
+# Missing constraints will be generated using the defaults values.
 network_constraints:
   enable: true
   default_delay: 25ms

--- a/reservation.yaml.topology.sample
+++ b/reservation.yaml.topology.sample
@@ -1,0 +1,65 @@
+---
+# ############################################### #
+# Grid'5000 reservation parameters                #
+# ############################################### #
+
+name: discovery-kolla
+walltime: "06:00:00"
+
+topology:
+  grp1:
+    paravance: 
+      control: 1
+      network: 1
+  grp[2-4]:
+    paravance: 
+      compute: 1
+
+network_constraints:
+  enable: true
+  default_delay: 25ms
+  default_rate: 100mbit
+  constraints:
+    - src: grp1
+      dst: grp[2-4]
+      delay: 10ms
+      rate: 1gbit
+      symetric: true
+
+vlans:
+  # mandatory : you need to have exacly one vlan
+  rennes: "{type='kavlan'}/vlan=1"
+
+# Be less strict on node distribution especially
+# when nodes are missing in the reservation
+# or not deployed
+role_distribution: debug
+enable_monitoring: true
+
+# ############################################### #
+# Inventory to use                                #
+# ############################################### #
+
+# This will describe the topology of your services
+inventory: inventories/inventory.sample
+
+# ############################################### #
+# docker registry parameters
+# ############################################### #
+registry:
+  ceph: true 
+  ceph_keyring: /home/discovery/.ceph/ceph.client.discovery.keyring
+  ceph_id: discovery
+  ceph_rbd: discovery_kolla_registry/datas
+  ceph_rbd: msimonin_registry0/datas
+
+
+# ############################################### #
+# Kolla parameteres (globals.yml)                 # 
+# ############################################### #
+kolla:
+  kolla_base_distro: "centos"
+  kolla_install_type: "source"
+  openstack_release: "3.0.2"
+  docker_namespace: "beyondtheclouds"
+  enable_heat: "yes"


### PR DESCRIPTION
Groups are introduced in the configuration file in order to easily describe
network constraints between them.  Constraints are enforced using a new
task : `tc`.  From a high level point of view this command will apply a set of
traffic shapping rules according to the group description.

Groups are described using the configuration file :
```
topology:
  grp1:
    parasilo:
      control: 1
      network: 1
  grp[2-4]:
    parasilo:
      compute: 1
```

Note that group expansion are possible, `grp[2-4]` is a concise way to
describe grp2, grp3 and grp4
Note that old `resources` is still supported. But specifying a `topology key
will override it.

Network constraints are described through the following matrix
(excerpt) in the configuration file:

```
network_constraints:
  default_delay: 50ms
  default_rate: 1gbit
  constraints:
    - src: grp1
      dst: grp[2-4]
      delay: 100ms
      symetric: true
```

Note that group expansion is also possible in `network_constraints`.
Note that `symetric` is optionnal (false by default).
Note that an `enable` key is also available. Setting it to `false` will
reset all the rules enforced.

Workflow:

* At deployment time, groups are merged to create the `resources` description as
it would have been previously (without groups)

* During the provider init, nodes are distributed into roles (as before) and into
groups (new feature). More precisely the `env[rsc]` will contains roles (as
before) and groups (new). As a consequence the generated `multinode` file will
also contain the groups descriptions.

* After the OpenStack deployment the `tc` command will :

1) Retrieve all the ips of all the nodes in play for all interfaces.
This is done through a dedicated ansible playbook : `utils/ips.yml`

2) Build the description of the rules to apply on nodes.
A rule is composed of a source node, a device (on which to apply the rule), the
destination ip, the desired rate and delay. For this particular step, we thus
need to calculate the cartesian product of the informations given by the first
step.

3) Apply the rules. This is done with an ansible playbool : `utils/tc.yml`

Additionnaly a quick check can be performed using the `utils/test.yml` playbook.

Further Notes :
 * Groups (grp1, grp2 ...) in the `multinode` are unused for now.
 * Enforcing network constraints is slow in this implementation as every
node receive all the rules. Alternatively we could send to the nodes its own
rules.
 * At the time of the implementation, I chose to put the network
constraints in the environment. It can makes the env much bigger than
before.