### PR TITLE
Add an option to switch of experiments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,3 +101,4 @@ ENV/
 
 ### Ansible ###
 *.retry
+default.nix

--- a/enos/utils/enostask.py
+++ b/enos/utils/enostask.py
@@ -4,11 +4,26 @@ from constants import SYMLINK_NAME, KOLLA_REPO, KOLLA_REF
 from functools import wraps
 
 import os
+import sys
 import yaml
 import logging
 
 
-def load_env():
+def make_env(env_path=None):
+    """Loads the `env_path` environment if not `None` or makes a new one.
+
+    An enos environment handles all specific variables of an
+    experiment. This function either generates a new environment or
+    loads a previous one. If the value of `env_path` is `None`, then
+    this function makes a new environment and return it. If the value
+    is a file path of a yaml file that represents the enos
+    environment, then this function loads and returns it.
+
+    In case of a file_path, this function also reread the
+    configuration file (the reservation.yaml) and reloads it. This
+    lets the user update is configuration between each phase.
+
+    """
     env = {
         'config':      {},  # The config
         'resultdir':   '',  # Path to the result directory
@@ -20,32 +35,40 @@ def load_env():
         'kolla_branch': KOLLA_REF
     }
 
-    # Loads the previously saved environment (if any)
-    env_path = os.path.join(SYMLINK_NAME, 'env')
-    if os.path.isfile(env_path):
-        with open(env_path, 'r') as f:
-            env.update(yaml.load(f))
-            logging.debug("Reloaded config %s", env['config'])
+    if env_path:
+        if os.path.isfile(env_path):
+            with open(env_path, 'r') as f:
+                env.update(yaml.load(f))
+                logging.debug("Loaded environment %s", env_path)
+        else:
+            logging.error("Wrong environment file %s", env_path)
+            sys.exit(1)
 
-    # Resets the configuration of the environment
-    if os.path.isfile(env['config_file']):
-        with open(env['config_file'], 'r') as f:
-            env['config'].update(yaml.load(f))
-            logging.debug("Reloaded config %s", env['config'])
+        # Resets the configuration of the environment
+        if os.path.isfile(env['config_file']):
+            with open(env['config_file'], 'r') as f:
+                env['config'].update(yaml.load(f))
+                logging.debug("Reloaded config %s", env['config'])
 
     return env
 
 
 def save_env(env):
+    """Saves one environment."""
     env_path = os.path.join(env['resultdir'], 'env')
 
     if os.path.isdir(env['resultdir']):
         with open(env_path, 'w') as f:
             yaml.dump(env, f)
 
-
 def enostask(doc):
-    """Decorator for a Enos Task."""
+    """Decorator for a Enos Task.
+
+
+    This decorator lets you define a new enos task and helps you
+    manage the environment.
+
+    """
     def decorator(fn):
         fn.__doc__ = doc
 
@@ -56,9 +79,8 @@ def enostask(doc):
                 provider_name = kwargs['--provider']
                 kwargs['provider'] = G5K()
 
-            # Loads the environment & set the config
-            env = load_env()
-            kwargs['env'] = env
+            # Constructs the environment
+            kwargs['env'] = make_env(kwargs['--env'])
 
             # Proceeds with the function executio
             fn(*args, **kwargs)

--- a/enos/utils/enostask.py
+++ b/enos/utils/enostask.py
@@ -86,6 +86,6 @@ def enostask(doc):
             fn(*args, **kwargs)
 
             # Save the environment
-            save_env(env)
+            save_env(kwargs['env'])
         return decorated
     return decorator


### PR DESCRIPTION
```
-e ENV --env=ENV  Path to the environment yaml file. You should
                  use this option when you wanna link to a specific
                  experiment. Not specifying this value will
                  discard the loading of the environment (it
                  makes sens for `up`).
```

For instance, to see info of an old experiment do:
`enos info -e path/to/old/xp/env`

Default ENV value by phase:
- up/deploy: `None`. Specifying a value will discard the creation of a new directory for results.
- init/os/bench/backup/info: Default value is the `current` directory

Doing an enos <phase> -h will print the value of ENV.

This commit works up until we use the `env['resultdir']` value rather than `SYMLINK` one into the code because I don't reset the symlink in init/os/bench/backup/info phases.