### PR TITLE
Allows to force the use of a single NIC

### DIFF
--- a/enos/ansible/group_vars/all.yml
+++ b/enos/ansible/group_vars/all.yml
@@ -4,6 +4,7 @@ cadvisor:
 g5k_role: unknown
 
 enable_monitoring: true
+single_interface: false
 
 # default openstack env
 os_env:

--- a/enos/ansible/group_vars/all.yml
+++ b/enos/ansible/group_vars/all.yml
@@ -4,7 +4,6 @@ cadvisor:
 g5k_role: unknown
 
 enable_monitoring: true
-single_interface: false
 
 # default openstack env
 os_env:

--- a/enos/provider/g5k.py
+++ b/enos/provider/g5k.py
@@ -30,7 +30,8 @@ DEFAULT_CONFIG = {
     "env_name": 'ubuntu1404-x64-min',
     "reservation": None,
     "vlans": {},
-    "role_distribution": ROLE_DISTRIBUTION_MODE_STRICT
+    "role_distribution": ROLE_DISTRIBUTION_MODE_STRICT,
+    "single_interface": False
 }
 MAX_ATTEMPTS = 5
 DEFAULT_CONN_PARAMS = {'user': 'root'}
@@ -83,7 +84,7 @@ class G5K(Provider):
         network_interface = str(interfaces[0])
         external_interface = None
 
-        if len(interfaces) > 1 and not config['single_interface']:
+        if len(interfaces) > 1 and not self.config['single_interface']:
             external_interface = str(interfaces[1])
             site, vlan = self._get_primary_vlan()
             # NOTE(msimonin) deployed is composed of the list of hostnames
@@ -98,7 +99,7 @@ class G5K(Provider):
         else:
             # TODO(msimonin) fix the network in this case as well.
             external_interface = 'veth0'
-            if config['single_interface']:
+            if self.config['single_interface']:
                 logging.warning("Forcing the use of a single network interface")
             else:
                 logging.warning("%s has only one NIC. The same interface "

--- a/enos/provider/g5k.py
+++ b/enos/provider/g5k.py
@@ -83,7 +83,7 @@ class G5K(Provider):
         network_interface = str(interfaces[0])
         external_interface = None
 
-        if len(interfaces) > 1:
+        if len(interfaces) > 1 and not config['single_interface']:
             external_interface = str(interfaces[1])
             site, vlan = self._get_primary_vlan()
             # NOTE(msimonin) deployed is composed of the list of hostnames
@@ -98,10 +98,13 @@ class G5K(Provider):
         else:
             # TODO(msimonin) fix the network in this case as well.
             external_interface = 'veth0'
-            logging.warning("%s has only one NIC. The same interface "
-                           "will be used for network_interface and "
-                           "neutron_external_interface."
-                           % self.config['resources'].keys()[0])
+            if config['single_interface']:
+                logging.warning("Forcing the use of a single network interface")
+            else:
+                logging.warning("%s has only one NIC. The same interface "
+                               "will be used for network_interface and "
+                               "neutron_external_interface."
+                               % self.config['resources'].keys()[0])
 
         self._exec_command_on_nodes(
             self.deployed_nodes,


### PR DESCRIPTION
This can be used to force the use of a single NIC,
e.g. when a second NIC appears to be available but
isn't actually working.
Displays a warning when 'single_interface' is set
to true.