### PR TITLE
Upgrade Enos for debian/jessie

### DIFF
--- a/enos/ansible/roles/bench/tasks/rally.yml
+++ b/enos/ansible/roles/bench/tasks/rally.yml
@@ -15,7 +15,12 @@
     state: started
     volumes:
     - /root/rally_home:/home/rally
-    command: rally-manage db recreate
+    command: rally-manage db create
+
+# NOTE(msimonin): without the pause
+# the file seems not to be synced in the next task.
+# Relaunching the play a second time is also a possible wokaround.
+- pause: seconds=1
 
 - name: Test whether the rally deployment has been created or not
   command: docker run -v /root/rally_home:/home/rally rallyforge/rally rally deployment list
@@ -38,6 +43,8 @@
 - name: debug
   debug: msg="rally task start {{ bench.location | basename }} --task-args '{{ bench.args }}'"
 
+# NOTE(msimonin): ansible 2.2.0 breaks the return value.
+# see https://github.com/BeyondTheClouds/enos/issues/41
 - name: Run rally benchmark
   docker_container:
     name: "{{ bench.location | to_uuid }}"
@@ -47,8 +54,6 @@
       - /root/rally_home:/home/rally
     command: rally task start {{ bench.location | basename }} --task-args '{{ bench.args }}'
   register: docker_output
-
-- debug: var=docker_output.ansible_facts.ansible_docker_container.Id
 
 - name: Wait for the end of the test, this may take a while...
   command: "docker ps -q --filter id={{ docker_output.ansible_facts.ansible_docker_container.Id }}"

--- a/enos/ansible/roles/collectd/tasks/main.yml
+++ b/enos/ansible/roles/collectd/tasks/main.yml
@@ -56,4 +56,7 @@
     - { src: haproxy.py, dst: /opt/collectd/haproxy/haproxy.py}
 
 - name: Restart collectd
-  service: name=collectd state=restarted
+  service:
+    name: collectd
+    state: restarted 
+

--- a/enos/ansible/roles/common/tasks/main.yml
+++ b/enos/ansible/roles/common/tasks/main.yml
@@ -3,25 +3,35 @@
   apt_key: keyserver=hkp://p80.pool.sks-keyservers.net:80 id=58118E89F3A912897C070ADBF76221572C52609D
 
 - name: Adding Docker apt repository
-  apt_repository: repo='deb https://apt.dockerproject.org/repo ubuntu-trusty main' state=present
+  apt_repository: repo='deb https://apt.dockerproject.org/repo debian-jessie main' state=present
 
 - name: Installing dependencies
   apt: name={{ item }} state=present update_cache=yes
   with_items:
-    - python-pip
     - docker-engine
-    - python-dev
     - curl
-    - python-httplib2
 
 - name: Allow Docker to use an insecure registry
-  lineinfile: dest=/etc/default/docker line="DOCKER_OPTS='--insecure-registry {{ registry_vip }}:4000 --registry-mirror=http://{{ registry_vip }}:4000'"
+  template:
+    src: docker.conf.j2
+    dest: /etc/systemd/system/docker.service
 
-- name: Restart Docker
-  service: name=docker state=restarted
+# NOTE(msimonin): ansible 2.2 introduces a systemctl module
+# But we need to wait until 
+# https://github.com/BeyondTheClouds/enos/issues/41
+- name: Restart docker daemon
+  command: systemctl daemon-reload
+
+- name: Restart docker dameon
+  command: systemctl restart docker
 
 - name: Mount /run
   command: mount --make-shared /run
 
+# NOTE(msimonin): 
+# freezing the version is due to 
+# see https://github.com/ansible/ansible/issues/17495
 - name: Install docker-py
-  pip: name=docker-py version=1.7.0
+  pip: 
+    name: docker-py
+    version: 1.7.0

--- a/enos/ansible/roles/common/templates/docker.conf.j2
+++ b/enos/ansible/roles/common/templates/docker.conf.j2
@@ -1,0 +1,3 @@
+[Service]
+ExecStart=
+ExecStart=/usr/bin/dockerd -H fd:// --insecure-registry {{ registry_vip }}:4000 --registry-mirror=http://{{ registry_vip }}:4000

--- a/enos/ansible/roles/registry/tasks/ceph.yml
+++ b/enos/ansible/roles/registry/tasks/ceph.yml
@@ -16,20 +16,37 @@
 
 - name: Checking rbd maps
   shell: "rbd --id {{ registry.ceph_id }} showmapped --format json"
-  register: rbd_maps
+  register: output
 
 # don't add a new mapping if there's already one
 # TODO: be more precise: 
 # check if the rbd is already in the mapped rbd
 - name: Add rbd mapping
   command: "rbd --id {{ registry.ceph_id }} map {{ registry.ceph_rbd }}"
-  when: rbd_maps.stdout == "{}"
+  when: output.stdout == "{}"
+
+- name: Checking rbd maps
+  shell: "rbd --id {{ registry.ceph_id }} showmapped --format json"
+  register: output
+
+- set_fact:
+    rbd_maps: "{{ output.stdout | from_json }}"
 
 - name: Create the registry directory
   file: 
     path: /mnt/registry
     state: directory  
 
+# Mount the rbd whose mapped pool/name correspond
+# to the one in the config file
 - name: Mount the Ceph device
-  mount: name=/mnt/registry src=/dev/rbd1 state=mounted fstype=auto
+  mount: 
+    name: /mnt/registry
+    src: "{{ item.value.device }}" 
+    state: mounted
+    fstype: auto
+  with_dict: "{{ rbd_maps }}"
+  when: 
+    - item.value.pool in registry.ceph_rbd 
+    - item.value.name in registry.ceph_rbd
 

--- a/enos/provider/g5k.py
+++ b/enos/provider/g5k.py
@@ -27,7 +27,7 @@ ROLE_DISTRIBUTION_MODE_STRICT = "strict"
 DEFAULT_CONFIG = {
     "name": "kolla-discovery",
     "walltime": "02:00:00",
-    "env_name": 'ubuntu1404-x64-min',
+    "env_name": 'jessie-x64-min',
     "reservation": None,
     "vlans": {},
     "role_distribution": ROLE_DISTRIBUTION_MODE_STRICT,
@@ -115,8 +115,14 @@ class G5K(Provider):
         # Install python on the nodes
         self._exec_command_on_nodes(
             self.deployed_nodes,
-            'apt-get -y install python',
+            'apt-get -y install python python-setuptools',
             'Installing Python on all the nodes...')
+        # fix installation of pip on jessie   
+        self._exec_command_on_nodes(
+            self.deployed_nodes,
+            'easy_install pip && ln -s /usr/local/bin /usr/bin/pip || true',
+            'Installing pip')
+
 
         return (roles,
                 map(str, vip_addresses),


### PR DESCRIPTION
The goal is to rely as much as possible on official supported images.

provider) python-pip is broken so we use easy-install to get pip.

ceph) the mapping was hard coded and worked for the ubuntu we
deployed but was problematic with jessie.

systemd ) jessie is using systemd, updated where necessary