### PR TITLE
Add password for nova placement api

### DIFF
--- a/enos/templates/passwords.yml
+++ b/enos/templates/passwords.yml
@@ -28,6 +28,7 @@ murano_database_password: demo
 murano_keystone_password: demo
 neutron_database_password: demo
 neutron_keystone_password: demo
+placement_keystone_password: demo
 nova_api_database_password: demo
 nova_database_password: demo
 nova_keystone_password: demo


### PR DESCRIPTION
Newton release introduces nova placement api [1]. The kolla/octata release adds the support for this api, but a password should be set [2].

[1] http://docs.openstack.org/developer/nova/placement.html
[2] https://github.com/openstack//kolla-ansible/commit/facfabf3bbf57d5302f1b53f29396c532ea87352