### PR TITLE
[doc] How to deploy from a dedicated node

### DIFF
--- a/docs/getting-started/grid5000.rst
+++ b/docs/getting-started/grid5000.rst
@@ -78,3 +78,14 @@ To launch the deployment, run:
 .. code-block:: bash
 
     python -m enos.enos deploy
+
+We suggest you to run the deployment from a dedicated node (especially for large
+deployment). For now the recommended way to do so is to reserve one node prior
+of your reservation. In the case of an interactive deployment :
+
+.. code-block:: bash
+
+    frontend) oarsub -I -l 'walltime=2:00:00'
+    node) <edit configuration>
+    node) python -m enos.enos deploy
+

--- a/enos/enos.py
+++ b/enos/enos.py
@@ -209,7 +209,8 @@ Options:
 """)
 def init_os(env=None, **kwargs):
     logging.debug('phase[init]: args=%s' % kwargs)
-    cmd = ['source %s' % os.path.join(SYMLINK_NAME, 'admin-openrc')]
+    cmd = []
+    cmd.append('. %s' % os.path.join(SYMLINK_NAME, 'admin-openrc'))
     # add cirros image
     images = [{'name': 'cirros.uec', 'url':'http://download.cirros-cloud.net/0.3.4/cirros-0.3.4-x86_64-disk.img'}]
     for image in images:
@@ -297,7 +298,7 @@ def init_os(env=None, **kwargs):
 
     cmd = '\n'.join(cmd)
     print(cmd)
-    call(cmd, shell = True)
+    call(cmd, shell=True)
 
 
 @enostask("""


### PR DESCRIPTION
Note that source the admin-openrc is done with '.' as bash seems not
to the default shell on g5k nodes.