### PR TITLE
Remove the openstack release version number from reservation file

### DIFF
--- a/reservation.yaml.sample
+++ b/reservation.yaml.sample
@@ -49,6 +49,5 @@ kolla_ref: "stable/newton"
 kolla:
   kolla_base_distro: "centos"
   kolla_install_type: "source"
-  openstack_release: "3.0.0"
   docker_namespace: "beyondtheclouds"
   enable_heat: "no"

--- a/reservation.yaml.topology.sample
+++ b/reservation.yaml.topology.sample
@@ -72,6 +72,5 @@ kolla_ref: "stable/newton"
 kolla:
   kolla_base_distro: "centos"
   kolla_install_type: "source"
-  openstack_release: "3.0.2"
   docker_namespace: "beyondtheclouds"
   enable_heat: "yes"


### PR DESCRIPTION
Kolla manage it automatically based on the kolla version [1].

[1] https://github.com/openstack/kolla-ansible/commit/2d32083a27d024aa4557469f09e393865ad60092