### PR TITLE
Increase docker ulimit in systemd configuration

### DIFF
--- a/enos/ansible/roles/common/templates/docker.conf.j2
+++ b/enos/ansible/roles/common/templates/docker.conf.j2
@@ -1,3 +1,5 @@
 [Service]
 ExecStart=
 ExecStart=/usr/bin/dockerd -H fd:// --insecure-registry {{ registry_vip }}:4000 --registry-mirror=http://{{ registry_vip }}:4000
+LimitMEMLOCK=infinity
+LimitNOFILE=16384

--- a/enos/enos.py
+++ b/enos/enos.py
@@ -168,7 +168,7 @@ def install_os(env=None, **kwargs):
         call("rm -rf %s" % kolla_path, shell=True)
 
     logging.info("Cloning Kolla")
-    call("git clone --depth=1 %s --branch %s %s > /dev/null" %
+    call("git clone %s --branch %s %s > /dev/null" %
             (env['config']['kolla_repo'], env['config']['kolla_ref'], kolla_path),
             shell=True)
 

--- a/inventories/inventory.sample
+++ b/inventories/inventory.sample
@@ -106,6 +106,10 @@ glance
 [nova-api:children]
 nova
 
+# quick fix here waiting for a more up to date inventory
+[placement-api:children]
+nova
+
 [nova-conductor:children]
 nova
 


### PR DESCRIPTION
By default docker containers are started with a ulimit -n set to
4096. Since we can't change the way docker containers are started
we enforce a global limit in systemd for all containeer to 16384.

Note the two quick fixes that need to be enforced for the deployment
to finish:
* clone the whole kolla repo so that pbr can infer the version number.
* add the placement-api in the inventory

Fix #69