### PR TITLE
Switch to an environment based on its directory name

### DIFF
--- a/enos/ansible/roles/patches/tasks/main.yml
+++ b/enos/ansible/roles/patches/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: Patching kolla
-  local_action: copy src={{ item.src }} dest={{ playbook_dir}}/../../current/{{ item.dst }}
+  local_action: copy src={{ item.src }} dest={{ resultdir }}/{{ item.dst }}
   with_items: patches
   when: "{{ item.enabled | bool }}"
   run_once: true

--- a/enos/utils/enostask.py
+++ b/enos/utils/enostask.py
@@ -3,11 +3,26 @@ from constants import SYMLINK_NAME
 from functools import wraps
 
 import os
+import sys
 import yaml
 import logging
 
 
-def load_env():
+def make_env(env_path=None):
+    """Loads the `env_path` environment if not `None` or makes a new one.
+
+    An enos environment handles all specific variables of an
+    experiment. This function either generates a new environment or
+    loads a previous one. If the value of `env_path` is `None`, then
+    this function makes a new environment and return it. If the value
+    is a file path of a yaml file that represents the enos
+    environment, then this function loads and returns it.
+
+    In case of a file_path, this function also reread the
+    configuration file (the reservation.yaml) and reloads it. This
+    lets the user update is configuration between each phase.
+
+    """
     env = {
         'config':      {},  # The config
         'resultdir':   '',  # Path to the result directory
@@ -17,32 +32,40 @@ def load_env():
         'user':        ''   # User id for this job
     }
 
-    # Loads the previously saved environment (if any)
-    env_path = os.path.join(SYMLINK_NAME, 'env')
-    if os.path.isfile(env_path):
-        with open(env_path, 'r') as f:
-            env.update(yaml.load(f))
-            logging.debug("Reloaded config %s", env['config'])
+    if env_path:
+        if os.path.isfile(env_path):
+            with open(env_path, 'r') as f:
+                env.update(yaml.load(f))
+                logging.debug("Loaded environment %s", env_path)
+        else:
+            logging.error("Wrong environment file %s", env_path)
+            sys.exit(1)
 
-    # Resets the configuration of the environment
-    if os.path.isfile(env['config_file']):
-        with open(env['config_file'], 'r') as f:
-            env['config'].update(yaml.load(f))
-            logging.debug("Reloaded config %s", env['config'])
+        # Resets the configuration of the environment
+        if os.path.isfile(env['config_file']):
+            with open(env['config_file'], 'r') as f:
+                env['config'].update(yaml.load(f))
+                logging.debug("Reloaded config %s", env['config'])
 
     return env
 
 
 def save_env(env):
+    """Saves one environment."""
     env_path = os.path.join(env['resultdir'], 'env')
 
     if os.path.isdir(env['resultdir']):
         with open(env_path, 'w') as f:
             yaml.dump(env, f)
 
-
 def enostask(doc):
-    """Decorator for a Enos Task."""
+    """Decorator for a Enos Task.
+
+
+    This decorator lets you define a new enos task and helps you
+    manage the environment.
+
+    """
     def decorator(fn):
         fn.__doc__ = doc
 
@@ -58,9 +81,8 @@ def enostask(doc):
                 klass = getattr(module, class_name)
                 kwargs['provider'] = klass()
 
-            # Loads the environment & set the config
-            env = load_env()
-            kwargs['env'] = env
+            # Constructs the environment
+            kwargs['env'] = make_env(kwargs['--env'])
 
             # Proceeds with the function executio
             fn(*args, **kwargs)


### PR DESCRIPTION
When calling Enos, a parameter `-e|--env` can be provided to specify an
environment. This commit requires to specify an environment directory rather
than an environment file.
If a given directory does not exist, it is created with a new environment.

Based on https://github.com/BeyondTheClouds/enos/pull/38