### PR TITLE
Add an except options in network_constraints

### DIFF
--- a/docs/network-emulation/index.rst
+++ b/docs/network-emulation/index.rst
@@ -64,3 +64,21 @@ Notes
 -----
 
 * To disable the network constraints you can specify :code:`enable: false` under the :code:`network_constraints` key and launch again :code:`python -m enos.enos tc`.
+* To exclude a group from any tc rule, you can add an optionnal :code:`except` key to the :code:`network_constraints` : 
+
+.. code-block:: yaml
+
+    network_constraints:
+      enable: true
+      default_delay: 25ms
+      default_rate: 100mbit
+      constraints:
+        - src: grp[1-3]
+          dst: grp[4-6]
+          delay: 10ms
+          rate: 1gbit
+          symetric: true
+      except:
+        - grp1
+
+

--- a/enos/utils/network_constraints.py
+++ b/enos/utils/network_constraints.py
@@ -35,17 +35,19 @@ def generate_default_grp_constraints(topology, network_constraints):
     """
     default_delay = network_constraints.get('default_delay')
     default_rate = network_constraints.get('default_rate')
+    except_groups = network_constraints.get('except', [])
     # expand each groups
     grps = map(lambda g: expand_groups(g), topology.keys())
     # flatten
     grps = [x for expanded_group in grps for x in expanded_group]
     # building the default group constraints
     return [{
-        'src': grp1,
-        'dst': grp2,
-        'delay': default_delay,
-        'rate': default_rate
-      } for grp1 in grps for grp2 in grps if grp1 != grp2]
+            'src': grp1,
+            'dst': grp2,
+            'delay': default_delay,
+            'rate': default_rate
+        } for grp1 in grps for grp2 in grps
+        if grp1 != grp2 and grp1 not in except_groups and grp2 not in except_groups]
 
 
 def generate_actual_grp_constraints(network_constraints):


### PR DESCRIPTION
From the network emulation perspective, you may want to exclude
a whole group. For instance monitoring traffic shouldn't be slowed
down. This can be achieved by dedicating a group to the monitoring
collector (influxdb) and excluding this group from any tc rules.

Fix #77