### PR TITLE
Specify the provider into the configuration file

### DIFF
--- a/docs/contribute/index.rst
+++ b/docs/contribute/index.rst
@@ -5,8 +5,8 @@ All contributions are welcome :
 
 * Feedbacks, bugs
 * New use cases
-* New providers
 * Bugs fixes
+* :doc:`new-provider`
 
 Please use the GitHub issue tracker.
 

--- a/docs/contribute/new-provider.rst
+++ b/docs/contribute/new-provider.rst
@@ -1,0 +1,73 @@
+.. _new-provider:
+
+New provider
+============
+
+The actual implementation gives two providers: :doc:`grid5000` and
+:doc:`vbox`. If you want to support another testbed, then implementing
+a new one is easy as 500 lines of Python code.
+
+The new provider should follow the `provider.py`_ interface which
+consists in four methods: ``init``, ``destroy``, ``before_preintsall``
+and ``after_preinstall``.
+
+.. _provider.py: https://github.com/BeyondTheClouds/enos/blob/master/enos/provider/provider.py
+
+Init Method
+-----------
+
+The ``init`` method provides resources and provisions the environment.
+To let the provider knows what kind and how many resources should be
+provided, the method is fed with the ``config`` object that maps the
+reservations file. So a provider can access the resource description
+with:
+
+.. code-block:: python
+   rsc = config['resources']
+
+   # Use rsc to book resources ...
+
+At the end of the ``init`` the provider should return a list of hosts
+that Enos can SSH on, together with a pool of available IP for
+OpenStack Network.
+
+Destroy Method
+--------------
+
+The ``destoy`` method destroys resources that have been used for the
+deployment. The provider can rely on the environment variable to get
+information related to its deployment.
+
+Before and After Preinstall Methods
+-----------------------------------
+
+During its up phase, Enos calls a provider to get resources and then
+provisions them with docker and other util tools. The provider can use
+theses two methods to perform extra actions before and after the
+provisioning.
+
+Provider Instantiation
+----------------------
+
+Enos automatically instantiates a provider based on the name specified
+in the ``reservation.yaml``. For instance, based on the following
+reservation file,
+
+.. code-block:: yaml
+   provider: "my-provider"
+
+Enos seeks for a file called ``my-provider.py`` into ``enos/provider``
+and instantiates its main class. But sometimes, the provider requires
+extra information for its initialisation. The good place for this
+information is to put it under the provider key. In this case, the
+provider name should be accessible throughout the ``type`` key:
+
+.. code-block:: yaml
+   provider:
+     type: "my-provider"
+     extra-var: ...
+     ...
+
+Then the provider can access ``extra-var`` with
+``config['provider']['extra-var']``. Supported extra information
+should be well documented into the provider documentation.

--- a/docs/getting-started/grid5000.rst
+++ b/docs/getting-started/grid5000.rst
@@ -1,3 +1,5 @@
+.. _grid5000:
+
 Grid'5000
 =========
 
@@ -89,4 +91,3 @@ of your reservation. In the case of an interactive deployment :
     node) source venv/bin/activate
     node) <edit configuration>
     node) python -m enos.enos deploy
-

--- a/docs/getting-started/vbox.rst
+++ b/docs/getting-started/vbox.rst
@@ -1,3 +1,5 @@
+.. _vbox:
+
 Virtualbox
 ==========
 
@@ -50,6 +52,7 @@ example the following is a valid resources description :
 
 
 .. code-block:: bash
+    provider: "vbox"
 
     resources:
       medium:
@@ -64,8 +67,8 @@ The list of the sizes may be found `here
 Deployment
 -----------
 
-To launch the deployment, run: 
+To launch the deployment, run:
 
 .. code-block:: bash
 
-    python -m enos.enos deploy --provider=vbox
+    python -m enos.enos deploy

--- a/enos/tests/utils/test_extra.py
+++ b/enos/tests/utils/test_extra.py
@@ -157,6 +157,35 @@ class TestBuildRoles(unittest.TestCase):
         self.assertListEqual(sorted(roles["grp2"] + roles["grp3"]), sorted(roles["compute"]))
 
 
+class TestMakeProvider(unittest.TestCase):
+
+    # TODO: test raises error
+    def __provider_env(self, provider_name):
+        "Returns env with a provider key"
+        return {"config": {"provider": provider_name}}
+
+    def __provider_env_ext(self, provider_name):
+        "Returns env with an extended provider key that may include options"
+        return {"config": {"provider": {"type": provider_name}}}
+
+    def test_make_g5k(self):
+        "Tests the creation of G5k provider"
+        from enos.provider.g5k import G5k
+        self.assertIsInstance(make_provider(self.__provider_env('g5k')), G5k)
+        self.assertIsInstance(make_provider(self.__provider_env_ext('g5k')), G5k)
+
+    def test_make_vbox(self):
+        "Tests the creation of Vbox provider"
+        from enos.provider.vbox import Vbox
+        self.assertIsInstance(make_provider(self.__provider_env('vbox')), Vbox)
+        self.assertIsInstance(make_provider(self.__provider_env_ext('vbox')), Vbox)
+
+    def test_make_unexist(self):
+        "Tests the raise of error for unknown/unloaded provider"
+        with self.assertRaises(ImportError):
+            make_provider(self.__provider_env('unexist'))
+
+
+
 if __name__ == '__main__':
     unittest.main()
-

--- a/enos/utils/enostask.py
+++ b/enos/utils/enostask.py
@@ -59,7 +59,6 @@ def save_env(env):
 def enostask(doc):
     """Decorator for a Enos Task.
 
-
     This decorator lets you define a new enos task and helps you
     manage the environment.
 
@@ -69,16 +68,6 @@ def enostask(doc):
 
         @wraps(fn)
         def decorated(*args, **kwargs):
-            if '--provider' in kwargs:
-                provider_name = kwargs['--provider']
-                package_name = '.'.join([
-                    'enos.provider',
-                    provider_name.lower()])
-                class_name = provider_name.capitalize()
-                module = __import__(package_name, fromlist=[class_name])
-                klass = getattr(module, class_name)
-                kwargs['provider'] = klass()
-
             # Constructs the environment
             kwargs['env'] = make_env(kwargs['--env'])
             # If no directory is provided, set the default one

--- a/enos/utils/extra.py
+++ b/enos/utils/extra.py
@@ -389,3 +389,26 @@ def _build_indexes(resources):
             s.extend(list(indexes))
             all_indexes.append(s)
     return all_indexes
+
+
+def make_provider(env):
+    """Instantiates the provider.
+
+    Seeks into the configuration for the `provider` value. The value
+    SHOULD be, either a *string*, or a *dictionary with a `type` key*
+    that gives the provider name. Then used this value to instantiate
+    and return the provider.
+
+    """
+    provider_name = env['config']['provider']['type']\
+                    if 'type' in env['config']['provider']\
+                    else env['config']['provider']
+
+    package_name = '.'.join(['enos.provider', provider_name.lower()])
+    class_name = provider_name.capitalize()
+    module = __import__(package_name, fromlist=[class_name])
+    klass = getattr(module, class_name)
+
+    logging.info("Loaded provider %s", module)
+
+    return klass()

--- a/reservation.yaml.sample
+++ b/reservation.yaml.sample
@@ -1,9 +1,13 @@
 ---
 # ############################################### #
-# Grid'5000 reservation parameters                #
+# Enos Configuration File                         #
 # ############################################### #
 
 name: OpenStack/Discovery-Enos2
+
+# Resources Provider. Values are: g5k, vbox
+provider: "g5k"
+
 walltime: "2:00:00"
 
 resources:
@@ -36,7 +40,6 @@ registry:
   ceph_keyring: /home/discovery/.ceph/ceph.client.discovery.keyring
   ceph_id: discovery
   ceph_rbd: discovery_kolla_registry/datas
-
 
 # ############################################### #
 # Kolla parameteres                               #

--- a/reservation.yaml.topology.sample
+++ b/reservation.yaml.topology.sample
@@ -1,10 +1,14 @@
 ---
 # ############################################### #
-# Grid'5000 reservation parameters                #
+# Enos Configuration File                         #
 # ############################################### #
 
 name: OpenStack/Discovery-Enos2
-walltime: "06:00:00"
+
+# Resources Provider. Values are: g5k, vbox
+provider: g5k
+
+walltime: "2:00:00"
 
 # Define a set of groups
 # The `resources` description will be overwritten by the


### PR DESCRIPTION
Resolves #79

Removes the support of `--provider=<>` from the command line and puts
this information into the reservation.yml. The user should specify a
provider name either with a String (ie, `provider: "g5k"`) or under a
specific key called type (ie, `provider: type: "g5k"`). The second
specification lets the provider add extra key under `provider:` (See
msimonin comment on #79).

About the implementation, I remove the building of the provider from
the enostask and move it into phases that need it, because keeping the
building in enostask makes the implementation really tricky.