### PR TITLE
Make annotations great again!

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,6 +1,7 @@
 [defaults]
 forks=200
 callback_plugins = ./enos/ansible/plugins/callback
+callback_whitelist = influxdb_events
 
 [ssh_connection]
 pipelining=True

--- a/docs/analysis/index.rst
+++ b/docs/analysis/index.rst
@@ -23,20 +23,16 @@ TODO
 Annotations
 -----------
 
-Enos embeds an Ansible plugin to add annotations in Grafana's graphs.
+Enos embeds an Ansible plugin to add annotations in Grafana.
 These annotations are marked points which provide rich information about events
-when hovered over. To enable this option, the plugin must be loaded and the
-monitoring stack must be deployed (i.e. ``enable_monitoring: true`` should be
-set in the configuration file).
+when hovered over.
+Enos uses the ``ansible.cfg`` file that loads the plugin. The plugin can be
+disabled by editing the line ``callback_whitelist = influxdb_events`` in the
+``ansible.cfg``. Note also that the plugin is automaticaly disabled when
+the monitoring tools are not deployed (i.e. when `enable_monitoring = false`
+is set in the configuration file).
 
-To enable the plugin, the ``ANSIBLE_CONFIG`` environment variable should be set
-to an ``ansible.cfg`` which loads the plugin. To that end, Enos can be called
-this way: ``ANSIBLE_CONFIG="./enos/ansible.cfg" python -m enos.enos deploy``,
-or you can export the variable for more convenience (more information about
-``ansible.cfg`` can be found `here
-<http://docs.ansible.com/ansible/intro_configuration.html>`_).
-
-Then, a compatible dashboard must be used in Grafana to display
-annotations. An example of such dashboard is available `here
+Once the deployment is finished, a compatible dashboard must be used in Grafana
+to display annotations. An example of such dashboard is available `here
 <https://github.com/BeyondTheClouds/kolla-g5k-results/blob/master/files/grafana/dashboard_annotations.json>`_.
 

--- a/docs/analysis/index.rst
+++ b/docs/analysis/index.rst
@@ -13,9 +13,30 @@ Setting ``enable_monitoring: true`` in the configuration file will deploy a moni
 All these services are accessible on their default ports.
 For instance you'll be able to access grafana dashboards on port ``3000`` of the node hosting grafana.
 
-Some dashboards are available `here <https://github.com/BeyondTheClouds/kolla-g5k-results/tree/master/files/grafana>`_
+Some dashboards are available `here <https://github.com/BeyondTheClouds/kolla-g5k-results/tree/master/files/grafana>`_.
 
 Post-mortem
 -----------
 
 TODO
+
+Annotations
+-----------
+
+Enos embeds an Ansible plugin to add annotations in Grafana's graphs.
+These annotations are marked points which provide rich information about events
+when hovered over. To enable this option, the plugin must be loaded and the
+monitoring stack must be deployed (i.e. ``enable_monitoring: true`` should be
+set in the configuration file).
+
+To enable the plugin, the ``ANSIBLE_CONFIG`` environment variable should be set
+to an ``ansible.cfg`` which loads the plugin. To that end, Enos can be called
+this way: ``ANSIBLE_CONFIG="./enos/ansible.cfg" python -m enos.enos deploy``,
+or you can export the variable for more convenience (more information about
+``ansible.cfg`` can be found `here
+<http://docs.ansible.com/ansible/intro_configuration.html>`_).
+
+Then, a compatible dashboard must be used in Grafana to display
+annotations. An example of such dashboard is available `here
+<https://github.com/BeyondTheClouds/kolla-g5k-results/blob/master/files/grafana/dashboard_annotations.json>`_.
+

--- a/docs/customization/index.rst
+++ b/docs/customization/index.rst
@@ -66,3 +66,13 @@ code to enable custom configuration files to be used (and by extension
 custom kolla code). See the possible patch declaration in
 ``ansible/group_vars/all.yml``. Patches should be added in the
 configuration file of the experiment.
+
+
+Ansible configuration
+--------------------
+
+By default, Enos loads its own ``ansible.cfg``. To use another Ansible
+configuration file, the ``ANSIBLE_CONFIG`` environment variable can be used.
+Further information can be found `here 
+<http://docs.ansible.com/ansible/intro_configuration.html>`_.
+

--- a/enos/ansible/plugins/callback/influxdb_events.py
+++ b/enos/ansible/plugins/callback/influxdb_events.py
@@ -3,25 +3,21 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-from datetime import datetime, date, time, timedelta
-import time
+from datetime import datetime
 import os
 import pwd
-import socket
-import json
-
-import sys
 
 from influxdb import InfluxDBClient
 
 from ansible.plugins.callback import CallbackBase
 
+
 class CallbackModule(CallbackBase):
     """
-    This callback module fills an influxdb with Ansible events, :
+    This callback module fills an InfluxDB with Ansible events:
     1. Create an empty list at the beginning of playbooks;
     2. Add an event to the list for each playbook/play/task;
-    3. Connect to influxdb at the end of playbooks if succeeded and commit
+    3. Connect to InfluxDB at the end of playbooks if succeeded and commit
     events.
     """
 
@@ -30,107 +26,150 @@ class CallbackModule(CallbackBase):
     CALLBACK_NAME = 'influxdb_events'
     CALLBACK_NEEDS_WHITELIST = False
 
-    def __init__(self):
 
+    def __init__(self):
         super(CallbackModule, self).__init__()
 
+        self.timer = None
         self.events = []
-        self.playbook = None
-        self.playbook_name = None
+        self.host_vars = None
+        self.timer = None
+        self.username = pwd.getpwuid(os.getuid()).pw_name
 
-    def report_event(self, event_type, fields):
-        """
-        Add a new event in the list
-        """
-        tags={}
-        tags['type'] = event_type
-        tags['user']= tags.get('user', self.username)
-        tags['hostname'] = tags.get('hostname', self.hostname)
+
+    def report_event(self, fields):
+        """Add a new event in the list"""
+
         current_time = datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%S.%f')
-        event = [
-            {
-                'time': current_time,
-                'measurement': 'events',
-                'tags': tags,
-                'fields': fields
-            }
-        ]
+
+        event = {
+            'time': current_time,
+            'measurement': 'events',
+            'fields': fields
+        }
+
         self.events.append(event)
 
+
+    def add_extra_tags(self, fields):
+        """Add extra tags to the event"""
+
+        # Add Kolla-related information in tags
+        fields['tags'] = '%s %s %s %s' % (fields['tags'],
+                self.host_vars.get('kolla_ref'),
+                self.host_vars.get('kolla_base_distro') or \
+                        self.host_vars['kolla']['kolla_base_distro'],
+                self.host_vars.get('kolla_install_type') or \
+                        self.host_vars['kolla']['kolla_install_type']
+        )
+
+        # Set the variables only available during the `os_install` phase
+        if self.host_vars.get('openstack_release', 'auto') != 'auto':
+            fields['tags'] = '%s %s' % (fields['tags'],
+                    self.host_vars.get('openstack_release'))
+
+        if 'openstack_region_name' in self.host_vars:
+            fields['tags'] = '%s %s' % (fields['tags'],
+                    self.host_vars.get('openstack_region_name'))
+
+
     def v2_playbook_on_start(self, playbook):
-        """
-        Logs each playbook start
-        """
-        self.username = pwd.getpwuid(os.getuid()).pw_name
-        self.hostname = socket.gethostname()
-        self.playbook = playbook
-        self.playbook_name = os.path.basename(playbook._file_name)
-        self.playbook_basedir = playbook._basedir
+        """Log each starting playbook"""
+
+        playbook_name = os.path.basename(playbook._file_name)
 
         fields = {
-            'text': 'Playbook %s started on %s by %s' %
-               (self.playbook_name, self.hostname, self.username)
+            'tags': 'playbook %s' % self.username,
+            'text': playbook_name,
+            'type': 'playbook',
+            'title': 'Playbook Started'
         }
-        self.report_event('playbook-start', fields)
+
+        self.report_event(fields)
+
 
     def v2_playbook_on_play_start(self, play):
-        """
-        Logs each play start
-        """
+        """Log each starting play"""
+
+        host = play._variable_manager._hostvars.keys()[0]
+        self.host_vars = play._variable_manager._hostvars[str(host)]
+
+        if not self.host_vars.get('enable_monitoring', True):
+            # Disable the plugin if InfluxDB is unreachable
+            self.disabled = True
+            self._display.warning("The plugin %s is disabled since "
+                "monitoring is disabled in the config file." %
+                self._original_path)
 
         fields = {
-            'text': '"%s" from playbook %s started on %s by %s' %
-                (play.name, self.playbook_name, self.hostname, self.username),
+            'tags': 'play %s' % self.username,
+            'text': play.name,
+            'type': 'play',
+            'title': 'Play Started'
         }
-        self.report_event('play-start', fields)
+
+        self.add_extra_tags(fields)
+        self.report_event(fields)
+
 
     def v2_playbook_on_task_start(self, task, is_conditional):
-        """
-        Logs each task start
-        """
+        """Restart the timer when a task starts"""
+
+        self.timer = datetime.now()
+
+
+    def v2_runner_on_ok(self, result):
+        """Log each finished task marked as 'changed'"""
+
+        # Log only "changed" tasks
+        if not result.is_changed():
+            return
+
+        # Record the time at the end of a task
+        end_timer = datetime.now()
+        m, s = divmod((end_timer - self.timer).seconds, 60)
+        h, m = divmod(m, 60)
+
+        taskname = result._task.get_name()
+        hostname = result._host
+
         fields = {
-            'text': 'Task %s started on %s by %s' %
-                (task.name, self.hostname, self.username)
+            'tags': 'task %s %s %02d:%02d:%02d' % (
+                self.username,
+                hostname,
+                h, m, s),
+            'text': taskname,
+            'type': 'task',
+            'title': 'Task Succeeded'
         }
-        self.report_event('task-start', fields)
+
+        # Add the event tag if it is not the default value
+        event_tag = result._task.tags[0]
+        if event_tag != 'always':
+            fields['tags'] = '%s %s' % (fields['tags'], event_tag)
+
+        self.add_extra_tags(fields)
+        self.report_event(fields)
+
 
     def v2_playbook_on_stats(self, stats):
-        """
-        Connect to influxdb and commit events
-        """
-        try:
-            variable_manager = self.playbook._entries[0]._variable_manager
-            extra_vars = variable_manager.extra_vars
-            _host = extra_vars['influx_vip']
-        except:
-            _host = os.getenv('influx_vip')
-            if not _host:
-                self._display.warning("\
-                    Couldn't find influxdb VIP in %s playbook\n\
-                    please export the following environment\
-                    variable: 'influx_vip'" %
-                    (self.playbook_name, _host, os.path.basename(__file__)) )
-                return
+        """Connect to InfluxDB and commit events"""
+
+        # Set InfluxDB host from an environment variable if provided
+        _host = os.getenv('influx_vip') or self.host_vars['influx_vip']
         _port = "8086"
         _user = "None"
         _pass = "None"
         _dbname = "events"
-        try:
-            self.influxdb = InfluxDBClient(_host, _port, _user, _pass, _dbname)
-        except:
-            """
-            If influxdb is not reachable, this plugin is disabled
-            ansible will not call any callback if disabled is set to True
-            """
-            self.disabled = True
-            self._display.warning("influxdb was not reachable in %s playbook\n\
-                please check the connectivity with %s\n\
-                the plugin %s is thus disabled" %
-                    (self.playbook_name, _host, os.path.basename(__file__)) )
-            return
-        self.influxdb.switch_database(_dbname)
-        self.influxdb.switch_user(_user, _pass)
+        influxdb = InfluxDBClient(_host, _port, _user, _pass, _dbname)
 
-        for event in self.events:
-            self.influxdb.write_points(event, time_precision='u')
+        try:
+            influxdb.write_points(self.events, time_precision='u')
+        except:
+            # Disable the plugin if writes fail
+            self.disabled = True
+            self._display.warning(
+                "Cannot write to InfluxDB, check the service state "
+                "on %s." % _host)
+            return
 

--- a/enos/ansible/plugins/callback/influxdb_events.py
+++ b/enos/ansible/plugins/callback/influxdb_events.py
@@ -24,7 +24,7 @@ class CallbackModule(CallbackBase):
     CALLBACK_VERSION = 2.0
     CALLBACK_TYPE = 'notification'
     CALLBACK_NAME = 'influxdb_events'
-    CALLBACK_NEEDS_WHITELIST = False
+    CALLBACK_NEEDS_WHITELIST = True
 
 
     def __init__(self):

--- a/enos/enos.py
+++ b/enos/enos.py
@@ -185,11 +185,17 @@ def install_os(env=None, **kwargs):
         'neutron_external_address':   pop_ip(env),
         'network_interface':          env['eths'][NETWORK_IFACE],
         'kolla_internal_vip_address': env['config']['vip'],
-        'neutron_external_interface': env['eths'][EXTERNAL_IFACE]
+        'neutron_external_interface': env['eths'][EXTERNAL_IFACE],
+        'influx_vip':                 env['config']['influx_vip'],
+        'kolla_ref':                  env['config']['kolla_ref']
     }
+    if 'enable_monitoring' in env['config']:
+        generated_kolla_vars['enable_monitoring'] = \
+                env['config']['enable_monitoring']
     generate_kolla_files(env['config']["kolla"],
                          generated_kolla_vars,
                          env['resultdir'])
+
 
     # Clone or pull Kolla
     kolla_path = os.path.join(env['resultdir'], 'kolla')


### PR DESCRIPTION
1. Add documentation.
2. An event handles now a 'title', a 'text' and 'tags':
    * title defines the event type (playbook, play, task);
    * text defines the event name;
    * tags contain further information about the event (user, node, kolla-related, task execution time).
3. Because recording every task saved too many useless information, tasks are
no longer recorded when they begin. In order to record only the tasks that
imply a modification (marked as 'changed' in Ansible), this commit checks the
status of tasks before adding them to InfluxDB.
4. InfluxDB connexion is tested, if not working, the plugin is disabled
and a warning message appears.
5. The configuration is provided to `kolla-ansible` to pass `influx_vip`
which is required to record events during the `os_install` phase, as well as
different information that could be used as tags.

Related to #11

Result:
![annotations8_crop](https://cloud.githubusercontent.com/assets/1255977/24043621/c12c008e-0b17-11e7-99e6-84d25b10db42.png)

Potential future step:
* Get annotations inside rally benchs.
* Other tags?