### PR TITLE
VBox : change provider name to vagrant

### DIFF
--- a/enos/provider/enos_vagrant.py
+++ b/enos/provider/enos_vagrant.py
@@ -7,8 +7,8 @@ from ..utils.extra import build_resources, expand_topology, build_roles
 from execo import Host
 
 import logging
-import vagrant
 import os
+import vagrant
 
 SIZES = {
     'tiny': {
@@ -34,9 +34,9 @@ SIZES = {
 }
 
 
-class Vbox(Provider):
+class Enos_vagrant(Provider):
     def init(self, config, calldir, force_deploy=False):
-        """python -m enos.enos up --provider=vbox
+        """python -m enos.enos up
         Read the resources in the configuration files.  Resource claims must be
         grouped by sizes according to the predefined SIZES map.
         """

--- a/enos/utils/extra.py
+++ b/enos/utils/extra.py
@@ -403,9 +403,11 @@ def make_provider(env):
     provider_name = env['config']['provider']['type']\
                     if 'type' in env['config']['provider']\
                     else env['config']['provider']
-
+    if provider_name == "vagrant" :
+        provider_name = "enos_vagrant"
     package_name = '.'.join(['enos.provider', provider_name.lower()])
     class_name = provider_name.capitalize()
+
     module = __import__(package_name, fromlist=[class_name])
     klass = getattr(module, class_name)
 

--- a/reservation.yaml.sample
+++ b/reservation.yaml.sample
@@ -5,7 +5,7 @@
 
 name: OpenStack/Discovery-Enos2
 
-# Resources Provider. Values are: g5k, vbox
+# Resources Provider. Values are: g5k, vagrant
 provider: "g5k"
 
 walltime: "2:00:00"


### PR DESCRIPTION
The vbox module is renamed enos_vagrant
to avoid conflict with the existing
vagrant module in use in enos