### PR TITLE
Use our own Host structure

### DIFF
--- a/docs/getting-started/vbox.rst
+++ b/docs/getting-started/vbox.rst
@@ -12,7 +12,6 @@ Vagrant setup
 To get started with the vagrant provider, you need to install
 
 * `Vagrant <https://www.vagrantup.com/>`_
-* `Vagrant hostmanager <https://github.com/devopsgroup-io/vagrant-hostmanager>`_ plugin
 
 Code setup
 ^^^^^^^^^^

--- a/enos/provider/host.py
+++ b/enos/provider/host.py
@@ -1,0 +1,22 @@
+class Host(object):
+
+    def __init__(
+            self,
+            address,
+            alias=None,
+            user=None,
+            keyfile=None,
+            port=None,
+            extra={}):
+        self.address = address
+        self.alias = alias
+        if self.alias is None:
+            self.alias = address
+        self.user = user
+        self.keyfile = keyfile
+        self.port = port
+        self.extra = extra
+
+    def __repr__(self):
+        args = [self.alias, "address=%s" % self.address]
+        return "Host(%s)" % ", ".join(args)

--- a/enos/templates/Vagrantfile.j2
+++ b/enos/templates/Vagrantfile.j2
@@ -11,10 +11,6 @@ easy_install pip && ln -s /usr/local/bin /usr/bin/pip || true
 SCRIPT
 
 Vagrant.configure(2) do |config|
-  config.hostmanager.enabled = true
-  config.hostmanager.manage_host = true
-  config.hostmanager.manage_guest = true
-  config.hostmanager.ignore_private_ip = false
   config.vm.box = "debian/contrib-jessie64"
   config.vm.provision "shell", inline: $script
 

--- a/enos/tests/utils/test_network_constraints.py
+++ b/enos/tests/utils/test_network_constraints.py
@@ -1,6 +1,6 @@
 import unittest
 from enos.utils.network_constraints import *
-from execo.host import Host
+from enos.provider.host import Host
 
 class TestExpandDescription(unittest.TestCase):
 

--- a/enos/utils/extra.py
+++ b/enos/utils/extra.py
@@ -1,21 +1,19 @@
 # -*- coding: utf-8 -*-
-from constants import TEMPLATE_DIR
-
+from ansible.executor.playbook_executor import PlaybookExecutor
 from ansible.inventory import Inventory
-from collections import namedtuple
 from ansible.parsing.dataloader import DataLoader
 from ansible.vars import VariableManager
-from ansible.executor.playbook_executor import PlaybookExecutor
+from collections import namedtuple
+from constants import TEMPLATE_DIR
 from itertools import groupby
-
 from netaddr import IPRange
-
 from subprocess import call
+
 import jinja2
-import os
-import yaml
 import logging
+import os
 import re
+import yaml
 
 # These roles are mandatory for the
 # the original inventory to be valid
@@ -114,8 +112,7 @@ def render_template(template_name, vars, output_path):
 
 
 def generate_inventory(roles, base_inventory, dest):
-    """
-    Generate the inventory.
+    """Generate the inventory.
     It will generate a group for each role in roles and
     concatenate them with the base_inventory file.
     The generated inventory is written in dest
@@ -127,6 +124,7 @@ def generate_inventory(roles, base_inventory, dest):
                 f.write(line)
 
     logging.info("Inventory file written to " + dest)
+
 
 def generate_inventory_string(n, role):
     i = [n.alias, "ansible_host=%s" % n.address]
@@ -214,8 +212,7 @@ def generate_kolla_files(config_vars, kolla_vars, directory):
 
 
 def to_abs_path(path):
-    """
-    if set, path is considered relative to the current working directory
+    """if set, path is considered relative to the current working directory
     if not just fail
     Note: this does not check the existence
     """
@@ -226,14 +223,13 @@ def to_abs_path(path):
 
 
 def build_resources(topology):
-    """
-    Build the resource list
+    """Build the resource list
     For now we are just aggregating all the resources
     This could be part of a flat resource builder
     """
 
     def merge_add(cluster_roles, roles):
-        """ merge two dicts, sum the values"""
+        """Merge two dicts, sum the values"""
         for role, nb in roles.items():
             cluster_roles.setdefault(role, 0)
             cluster_roles[role] = cluster_roles[role] + nb
@@ -247,8 +243,7 @@ def build_resources(topology):
 
 
 def expand_groups(grp):
-    """
-    Expand group names.
+    """Expand group names.
     e.g:
         * grp[1-3] -> [grp1, grp2, grp3]
         * grp1 -> [grp1]
@@ -416,7 +411,7 @@ def make_provider(env):
     provider_name = env['config']['provider']['type']\
                     if 'type' in env['config']['provider']\
                     else env['config']['provider']
-    if provider_name == "vagrant" :
+    if provider_name == "vagrant":
         provider_name = "enos_vagrant"
     package_name = '.'.join(['enos.provider', provider_name.lower()])
     class_name = provider_name.capitalize()

--- a/enos/utils/network_constraints.py
+++ b/enos/utils/network_constraints.py
@@ -117,19 +117,19 @@ def build_ip_constraints(rsc, ips, constraints):
             # one possible source
             # Get all the active devices for this source
             active_devices = filter(lambda x: x["active"],
-                                    local_ips[s.address]['devices'])
+                                    local_ips[s.alias]['devices'])
             # Get only the name of the active devices
             sdevices = map(lambda x: x['device'], active_devices)
             for sdevice in sdevices:
                 # one possible device
                 for d in rsc[gdst]:
                     # one possible destination
-                    dallips = local_ips[d.address]['all_ipv4_addresses']
+                    dallips = local_ips[d.alias]['all_ipv4_addresses']
                     # Let's keep docker bridge out of this
                     dallips = filter(lambda x: x != '172.17.0.1', dallips)
                     for dip in dallips:
-                        local_ips[s.address].setdefault('tc', []).append({
-                                'source': s.address,
+                        local_ips[s.alias].setdefault('tc', []).append({
+                                'source': s.alias,
                                 'target': dip,
                                 'device': sdevice,
                                 'delay': gdelay,

--- a/enos/utils/network_constraints.py
+++ b/enos/utils/network_constraints.py
@@ -1,10 +1,9 @@
-from extra import expand_groups
 import copy
+from extra import expand_groups
 
 
 def expand_description(desc):
-    """
-    Expand the description given the group names/patterns
+    """Expand the description given the group names/patterns
     e.g:
     {src: grp[1-3], dst: grp[4-6] ...} will generate 9 descriptions
     """
@@ -22,16 +21,14 @@ def expand_description(desc):
 
 
 def same(g1, g2):
-    """
-    Two network constraints are equals if they have the same
+    """Two network constraints are equals if they have the same
     sources and destinations
     """
     return g1['src'] == g2['src'] and g1['dst'] == g2['dst']
 
 
 def generate_default_grp_constraints(topology, network_constraints):
-    """
-    Generate default symetric grp constraints.
+    """Generate default symetric grp constraints.
     """
     default_delay = network_constraints.get('default_delay')
     default_rate = network_constraints.get('default_rate')
@@ -47,12 +44,12 @@ def generate_default_grp_constraints(topology, network_constraints):
             'delay': default_delay,
             'rate': default_rate
         } for grp1 in grps for grp2 in grps
-        if grp1 != grp2 and grp1 not in except_groups and grp2 not in except_groups]
+        if grp1 != grp2 and grp1 not in except_groups
+                                 and grp2 not in except_groups]
 
 
 def generate_actual_grp_constraints(network_constraints):
-    """
-    Generate the user specified constraints
+    """Generate the user specified constraints
     """
     if 'constraints' not in network_constraints:
         return []
@@ -72,8 +69,7 @@ def generate_actual_grp_constraints(network_constraints):
 
 
 def merge_constraints(constraints, overrides):
-    """
-    Merge the constraints avoiding duplicates
+    """Merge the constraints avoiding duplicates
     Change constraints in place.
     """
     for o in overrides:
@@ -87,8 +83,7 @@ def merge_constraints(constraints, overrides):
 
 
 def build_grp_constraints(topology, network_constraints):
-    """
-    Generate constraints at the group level,
+    """Generate constraints at the group level,
     It expands the group names and deal with symetric constraints.
     """
     # generate defaults constraints
@@ -103,8 +98,7 @@ def build_grp_constraints(topology, network_constraints):
 
 
 def build_ip_constraints(rsc, ips, constraints):
-    """
-    Generate the constraints at the ip/device level.
+    """Generate the constraints at the ip/device level.
     Those constraints are those used by ansible to enforce tc/netem rules.
     """
     local_ips = copy.deepcopy(ips)


### PR DESCRIPTION
Until now execo.Host was used to represent a host to connect to.
This was too limited for what we want (e.g express advanced connection
parameter through gateway host). So we decide to move to our own
implementation.

Note the following side effects/benefits
 * [vagrant] Hostmanager isn't require anymore and has been removed
 * [g5k][vagrant] codes has been modified to use the new structure (minor
modifications)
 * tc tasks has been modified as well to make use of the structure
(minor modifications)

fix #100