### PR TITLE
Allow a user to force kolla variables in conf

### DIFF
--- a/docs/customization/index.rst
+++ b/docs/customization/index.rst
@@ -5,10 +5,13 @@ Customizations
 Changing Kolla / Ansible variables
 -----------------------------------
 
-Custom Kolla / Ansible parameters can be put in the configuration file
-under the key ``kolla``. For instance, Kolla uses the
-``openstack_release`` parameter to fix the OpenStack version to deploy.
-So, Enos tells Kolla to deploy the ``4.0.0`` version with:
+Custom Kolla / Ansible parameters can be put in the configuration file under
+the key ``kolla``. The complete list of Kolla variables can be found `here
+<https://github.com/openstack/kolla-ansible/blob/master/ansible/group_vars/all.yml>`_.
+
+For instance, Kolla uses the ``openstack_release`` parameter to fix the
+OpenStack version to deploy.  So, Enos tells Kolla to deploy the ``4.0.0``
+version with:
 
 .. code-block:: yaml
 
@@ -24,6 +27,21 @@ change the git repository/reference of Kolla code with:
 
     kolla_repo: "https://git.openstack.org/openstack/kolla-ansible"
     kolla_ref: "stable/ocata"
+
+Note on the network interfaces:
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Providers do their best to configure the network decently. This probably doesn't
+cover all the possible use cases. But, if you know what interfaces are configured by
+the provider you can specify a more precise allocation under he ``kolla`` key.
+For instance :
+
+.. code-block:: yaml
+
+    kolla:
+      network_interface: eth1
+      neutron_external_interface: eth2
+      tunnel_interface: eth3
 
 Changing the topology
 ---------------------
@@ -69,10 +87,10 @@ configuration file of the experiment.
 
 
 Ansible configuration
---------------------
+----------------------
 
 By default, Enos loads its own ``ansible.cfg``. To use another Ansible
 configuration file, the ``ANSIBLE_CONFIG`` environment variable can be used.
-Further information can be found `here 
+Further information can be found : `see here 
 <http://docs.ansible.com/ansible/intro_configuration.html>`_.
 

--- a/enos/utils/extra.py
+++ b/enos/utils/extra.py
@@ -185,9 +185,9 @@ def to_ansible_group_string(roles):
 
 def generate_kolla_files(config_vars, kolla_vars, directory):
     # get the static parameters from the config file
-    kolla_globals = config_vars
+    kolla_globals = kolla_vars
     # add the generated parameters
-    kolla_globals.update(kolla_vars)
+    kolla_globals.update(config_vars)
     # write to file in the result dir
     globals_path = os.path.join(directory, 'globals.yml')
     with open(globals_path, 'w') as f:


### PR DESCRIPTION
Before, we overloaded the kolla config by the generated kolla vars by Enos.
Now we do the opposite allowing user defined variables to take precedence
on those set by the framework.
As a side effect users can specify manually the network mapping they
want.

For #16