### PR TITLE
enos init: switch to openstack cli for neutron

### DIFF
--- a/enos/enos.py
+++ b/enos/enos.py
@@ -322,8 +322,8 @@ def init_os(env=None, **kwargs):
     # create a router between this two networks
     cmd.append('openstack router create router')
     # NOTE(msimonin): not sure how to handle these 2 with openstack cli
-    cmd.append('neutron router-gateway-set router public')
-    cmd.append('neutron router-interface-add router private-subnet')
+    cmd.append('openstack router set router --external-gateway public')
+    cmd.append('openstack router add subnet router private-subnet')
 
     cmd = '\n'.join(cmd)
 

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,6 @@ setup(
         'docopt==0.6.2',
         'httplib2==0.9.2',
         'python-dateutil==2.2',
-        'python-neutronclient==6.1.0',
         'python-openstackclient>=3.0.0,<=4.0.0',
         'python-vagrant==0.5.14',
 #        'python-blazarclient==0.2.0'


### PR DESCRIPTION
Switches from the neutron cli to the openstack cli for Neutron commands in `enos init`.
`neutron router-gateway-set router public` -> `openstack router set router --external-gateway public`

`neutron router-interface-add router private-subnet` -> `openstack router add subnet router private-subnet`

Tested with python-openstackclient 3.11.0, the resulting network looks alright.