### PR TITLE
Expose all kolla commands to Enos

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -29,7 +29,7 @@ commands =
 ignore = E121,E122,E123,E124,E125,E127,E128,E129,E131,E241,H405
 show-source = true
 exclude = venv,.git,.tox,dist,*egg,ansible,tests
-max-complexity = 14
+max-complexity = 12
 
 # Instruct travis which envs to run
 [travis]


### PR DESCRIPTION
```
usage: enos kolla [-e ENV|--env=ENV] [-s|--silent|-vv] -- <command>...

Run arbitrary Kolla command.

Options:
  -e ENV --env=ENV     Path to the environment directory. You should
                       use this option when you want to link a specific
                       experiment.
  -h --help            Show this help message.
  -s --silent          Quiet mode.
  -vv                  Verbose mode.
  command              Kolla command (e.g prechecks, checks, pull)
```

Example :
```
enos kolla -- pull --tags nova
```

In addition to that, destroy now accepts a soft deploy mode (default mode) where
all containers, configuration and volumes are removed. It has also an optionnal
--include-images which will remove all the docker images.

In my opinion this is very very practical when it comes to iterate on kolla code
(or conf) :
```
enos deploy
while(not ok):
    <hack kolla code>
    enos destroy
    enos os
```