### PR TITLE
ci: sanity_check clean vm and backup

### DIFF
--- a/tests/functionnal/tests/utils.sh
+++ b/tests/functionnal/tests/utils.sh
@@ -17,9 +17,13 @@ nova\
   --flavor m1.tiny\
   --nic net-id=$(openstack network show private --column id --format value)\
   jenkins-vm
+nova delete jenkins-vm
 
-  echo "-ENOS BENCH-"
-  enos bench --workload=$BASE_DIR/enos/workload
+echo "-ENOS BENCH-"
+enos bench --workload=$BASE_DIR/enos/workload
 
-  echo "-/SANITY CHECK-"
+echo "-ENOS BACKUP-"
+enos backup
+
+echo "-/SANITY CHECK-"
 }


### PR DESCRIPTION
* Destroy the created server, otherwise
Kolla destroy complains about running VMs

* Add backup phase to the sanity_check

Reminder: sanity_check is common to all functionnal tests and targets to validate the classical workflow in use in EnOS. This can be cherry_picked to stable/ocata.