### PR TITLE
Correct name for kolla variable: enable_neutron_dvr

### DIFF
--- a/tests/functionnal/tests/packaging/SUBJECT.org
+++ b/tests/functionnal/tests/packaging/SUBJECT.org
@@ -676,9 +676,9 @@ Neutron service that is inside ~grp1~ and VMs are inside the ~grp2~
 
 Now, reconfigure Neutron to use DVR[fn:dvr]. DVR will push Neutron
 agent directly on compute of ~grp2~ and ~grp3~. With EnOS, you should
-do so by updating the ~reservation.yaml~ and add ~enable_dvr: "yes"~
-under the ~kolla~ key. Then call the following line to tell EnOS to
-reconfigure Neutron:
+do so by updating the ~reservation.yaml~ and add ~enable_neutron_dvr:
+"yes"~ under the ~kolla~ key. Then call the following line to tell
+EnOS to reconfigure Neutron:
 : enos os --tags=neutron --reconfigure
 
 Finally, re-execute the ~dense_l3_east_west~ scenario and compare your


### PR DESCRIPTION
The variable for enabling the DVR is wrong and never existed with that
name in kolla.  The correct name is enable_neutron_dvr.  See:

- http://git.openstack.org/cgit/openstack/kolla-ansible/tree/releasenotes/notes/add-neutron-dvr-f1b3541e22c0fbc3.yaml
- http://git.openstack.org/cgit/openstack/kolla/tree/releasenotes/notes/add-neutron-dvr-f1b3541e22c0fbc3.yaml