### PR TITLE
[doc] update g5k provider

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -8,19 +8,12 @@ Installation
 
 .. code-block:: bash
 
-    $ pip install enos
+    $ pip install -U enos
 
 You may prefer to go with a virtualenv. Please refer to the
 `virtualenv <https://virtualenv.pypa.io/en/stable/>`_ documentation
 and the rest of this section for further information.
 
-
-If virtualenv is missing:
-
-.. code-block:: bash
-
-    $ pip install virtualenv --user     # Install virtualenv
-    $ export PATH=~/.local/bin/:${PATH} # Put it into your path
 
 Then install enos inside a virtualenv:
 
@@ -29,6 +22,7 @@ Then install enos inside a virtualenv:
     $ mkdir my-experiment && cd my-experiment
     $ virtualenv venv
     $ source venv/bin/activate
+    (venv) $ pip install -U pip
     (venv) $ pip install enos
 
 

--- a/docs/provider/grid5000.rst
+++ b/docs/provider/grid5000.rst
@@ -10,6 +10,14 @@ Installation
 Connect to the frontend of your choice.
 Then, refer to the :ref:`installation` section to install Enos.
 
+If virtualenv is missing:
+
+.. code-block:: bash
+
+    $ pip install virtualenv --user     # Install virtualenv
+    $ export PATH=~/.local/bin/:${PATH} # Put it into your path
+
+
 Configuration
 -------------
 
@@ -42,19 +50,6 @@ of your reservation. In the case of an interactive deployment:
     node) <edit configuration>
     node) enos deploy
 
-Enos will need to access the G5K api from this node. In order to do so you need
-to instruct execo to use the external endpoint of the API :
-
-.. code-block:: bash
-
-    cat ~/.execo.conf.py:
-
-    g5k_configuration = {
-        'api_username': '<your login>',
-        'api_uri': "https://api-ext.grid5000.fr/3.0/",
-    }
-
-You will be asked for your password at start.
 
 Default provider configuration
 -------------------------------


### PR DESCRIPTION
* move virtualenv specific installation to the provider
* force pip to be upgraded
* api-ext isn't necessary to access the g5k api from a dedicated node