### PR TITLE
Select the correct security group for rule

### DIFF
--- a/enos/enos.py
+++ b/enos/enos.py
@@ -313,12 +313,18 @@ def init_os(env=None, **kwargs):
                ' -c interfaces_info -f value|fgrep -v "[]" || '
                'openstack router add subnet router private-subnet')
 
+    # Get admin security group id
+    cmd.append('ADMIN_PROJECT_ID=$(openstack project list'
+               ' --user admin -c ID -f value)')
+    cmd.append('ADMIN_SEC_GROUP=$(openstack security group list'
+               ' --project ${ADMIN_PROJECT_ID} -c ID -f value)')
+
     # Security groups - allow everything
     cmd.append('for i in $(openstack security group rule list -c ID -f value);'
                'do openstack security group rule delete $i; done')
     protos = ['icmp', 'tcp', 'udp']
     for proto in protos:
-        cmd.append("openstack security group rule create default"
+        cmd.append("openstack security group rule create ${ADMIN_SEC_GROUP}"
                    " --protocol %s"
                    " --dst-port 1:65535"
                    " --src-ip 0.0.0.0/0" % proto)


### PR DESCRIPTION
Setting up network adds new security groups. So, the init ends up
with two "default" security group: one for the admin, and another one.
This commit specifies to set rules on admin security group.

The snippet comes from kolla-ansible [1]. It has been tested on G5k.

[1] https://github.com/openstack/kolla-ansible/blob/master/tools/init-runonce#L77