### PR TITLE
Add Debian unfree apt repository (for netperf)

### DIFF
--- a/enos/ansible/roles/utils/tasks/test.yml
+++ b/enos/ansible/roles/utils/tasks/test.yml
@@ -1,14 +1,17 @@
 ---
-- name: Installing netperf
-  apt:
-    name: netperf
-    allow_unauthenticated: yes
-    update_cache: true
+- name: Active unfree repository (for netperf)
+  apt_repository:
+    repo: deb http://deb.debian.org/debian/ stable main contrib non-free
+    state: present
+    update_cache: yes
+  when: ansible_os_family == 'Debian'
 
-- name: Installing fping
+- name: Installing fping, netperf
   apt:
-    name: fping
-    update_cache: true
+    name: "{{ item }}"
+  with_items:
+    - fping
+    - netperf
 
 - name: Installing flent 
   pip: 


### PR DESCRIPTION
Netperf is available into the unfree directory. This commit add the
unfree repository to apt/source.list, so we can install netperf. Note
that the unfree repository is activated by default in G5k debian9 kaenv.

For unbuntu, netperf is available into multiverse repo. The multiverse
repo seems activated by default. At least, this is the case for the
ubuntu/xenial64 vagrant box.

- Tested on g5k
- Tested on vagrant -- [ci/vagrant-vbox/51][2]
- Tested with topology -- [ci/vagrant-vbox-topo/41][1]

Fix #222

[1]: https://ci.inria.fr/beyondtheclouds/job/enos-vagrant-vbox-topology-params/41/
[2]: https://ci.inria.fr/beyondtheclouds/job/enos-vagrant-vbox-params/51/