### PR TITLE
Fix kolla command + env_file

### DIFF
--- a/enos/provider/g5k.py
+++ b/enos/provider/g5k.py
@@ -200,11 +200,6 @@ class G5k(Provider):
         provider_conf = conf['provider']
         # we put the nodes in the first vlan we have
         vlan = self._get_primary_vlan(vlans)
-        # Deploy all the nodes
-        logging.info("Deploying %s on %d nodes %s" % (
-            provider_conf['env_name'],
-            len(nodes),
-            '(forced)' if force_deploy else ''))
 
         kw = {
             'hosts': nodes,
@@ -212,8 +207,14 @@ class G5k(Provider):
         }
         if provider_conf.get('env_file'):
             kw.update({'env_file': provider_conf.get('env_file')})
+            provider_conf.pop('env_name')
         if provider_conf.get('env_name'):
             kw.update({'env_name': provider_conf.get('env_name')})
+
+        logging.info("%s deploying %s nodes with %s" % (
+            '(forced)' if force_deploy else '',
+            len(nodes),
+            kw))
 
         deployed, undeployed = EX5.deploy(
             EX5.Deployment(**kw), check_deployed_command=not force_deploy)

--- a/enos/provider/g5k.py
+++ b/enos/provider/g5k.py
@@ -206,12 +206,17 @@ class G5k(Provider):
             len(nodes),
             '(forced)' if force_deploy else ''))
 
+        kw = {
+            'hosts': nodes,
+            'vlan': vlan[1],
+        }
+        if provider_conf.get('env_file'):
+            kw.update({'env_file': provider_conf.get('env_file')})
+        if provider_conf.get('env_name'):
+            kw.update({'env_name': provider_conf.get('env_name')})
+
         deployed, undeployed = EX5.deploy(
-            EX5.Deployment(
-                nodes,
-                env_name=provider_conf['env_name'],
-                vlan=vlan[1]
-            ), check_deployed_command=not force_deploy)
+            EX5.Deployment(**kw), check_deployed_command=not force_deploy)
 
         # Check the deployment
         if len(undeployed) > 0:

--- a/tests/functionnal/tests/grid5000_env/deploy.sh
+++ b/tests/functionnal/tests/grid5000_env/deploy.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+set -xe
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+BASE_DIR="${SCRIPT_DIR}/../../../.."
+
+cd "$SCRIPT_DIR"
+
+
+# shellcheck disable=SC1091
+. ../utils.sh
+
+rm -rf venv
+virtualenv venv
+# shellcheck disable=SC1091
+. venv/bin/activate
+
+pip install -U pip
+
+pip install -e "$BASE_DIR"
+
+# pulling the images
+enos up
+enos kolla -- pull

--- a/tests/functionnal/tests/grid5000_env/jenkins.sh
+++ b/tests/functionnal/tests/grid5000_env/jenkins.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+set -xe
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+BASE_DIR=../../../..
+
+cd $SCRIPT_DIR
+
+. ../utils.sh
+
+sudo ../enos_deps.sh
+
+sudo adduser discovery ci
+sudo chown ci:ci -R $BASE_DIR
+sudo chmod 774 -R $BASE_DIR
+sudo rm -rf venv
+
+# removing previously installed images
+command -v docker && (sudo docker ps -q | xargs sudo docker rm -f)
+command -v docker && (sudo docker images -q | xargs sudo docker rmi)
+
+sudo -u discovery ./deploy.sh
+
+# stopping some containers
+command -v docker && ( sudo docker ps -q | xargs sudo docker stop)
+
+# saving the env
+sudo tgz-g5k > /tmp/enos.tgz

--- a/tests/functionnal/tests/grid5000_env/reservation.yaml
+++ b/tests/functionnal/tests/grid5000_env/reservation.yaml
@@ -1,0 +1,71 @@
+
+---
+# ############################################### #
+# Enos Configuration File                         #
+# ############################################### #
+
+# Resources description : this is provider specific
+hosts:
+  1: &h1
+    address: 127.0.0.1
+    alias: enos-node
+    user: root
+
+resources:
+  control:
+    - *h1
+  network:
+    - *h1
+  compute:
+    - *h1
+
+# Provider description and its options
+provider:
+  type: static
+  network:
+    start: 192.168.143.3
+    end:  192.168.143.119
+    cidr: 192.168.143.0/24
+    gateway: 192.168.143.1
+    dns: 8.8.8.8
+    extra_ips:
+      - 192.168.142.100
+      - 192.168.142.101
+      - 192.168.142.102
+      - 192.168.142.103
+      - 192.168.142.104
+  eths:
+    - eth1
+    - eth2
+
+# ############################################### #
+# Inventory to use                                #
+# ############################################### #
+
+# This will describe the topology of your services
+inventory: inventories/inventory.sample
+
+# true iff a monitoring stack should be deployed
+# cadvisor/collectd - influxdb - grafana
+enable_monitoring: true
+
+registry:
+  type: none
+
+# ############################################### #
+# Kolla parameters                                #
+# ############################################### #
+# Repository
+kolla_repo: https://git.openstack.org/openstack/kolla-ansible
+kolla_ref: master
+
+# globals.yml
+kolla:
+  kolla_base_distro: centos
+  kolla_install_type: source
+  docker_namespace: beyondtheclouds
+  openstack_release: latest
+  # openstack_logging_debug: True
+  enable_heat: "no"
+
+  node_custom_config: patch/


### PR DESCRIPTION
There was an implicit assumption when using the kolla command : `enos
kolla` can be only run after `enos os`. Indeed the kolla source
directory needed be installed in the experiment directory.

In order to be able to use the `kolla` command even if the `os` command
wasn't run before, we check if the sources are present and download them
if necessary. This code is shared between the install_os and kolla
command.

Note that `enos up` must be called before in any case.

So now the behaviour is

- enos os: install and bootstrap kolla sources and overwrite them if a previous installation is
    present

enos kolla: installs and bootstrap kolla sources only if a previous installation isn't
    present