### PR TITLE
remove openstack_release from the reservation template

### DIFF
--- a/enos/templates/reservation.yaml.sample
+++ b/enos/templates/reservation.yaml.sample
@@ -161,5 +161,4 @@ kolla:
   kolla_base_distro: "centos"
   kolla_install_type: "source"
   docker_namespace: "beyondtheclouds"
-  openstack_release: "latest"
   enable_heat: "no"


### PR DESCRIPTION
removing openstack_release: "latest" which lead to a mismatch between the deployed version of the containers and the code of kolla used (https://github.com/BeyondTheClouds/enos/issues/247)