### PR TITLE
Add fping to the list of requirements

### DIFF
--- a/enos/ansible/roles/common/tasks/pull.yml
+++ b/enos/ansible/roles/common/tasks/pull.yml
@@ -7,6 +7,7 @@
   with_items:
     - python-setuptools
     - kvm
+    - fping
 
 - easy_install:
     name: pip


### PR DESCRIPTION
This is used in when validating the network constraints.
This addresses very partially to the offline deployment problem.

For #303