### PR TITLE
Align the code with future enoslib 2.x.y.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 sudo: false
 language: python
 python:
-    - "2.7"
     - "3.5"
     - "3.6"
 install: pip install tox-travis

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -15,12 +15,12 @@ You may prefer to go with a virtualenv. Please refer to the
 and the rest of this section for further information.
 
 
-Then install enos inside a virtualenv:
+Then install enos inside a virtualenv (python3.5+ required):
 
 .. code-block:: bash
 
     $ mkdir my-experiment && cd my-experiment
-    $ virtualenv venv
+    $ virtualenv -p python3 venv
     $ source venv/bin/activate
     (venv) $ pip install -U pip
     (venv) $ pip install enos

--- a/docs/tutorial/index.org
+++ b/docs/tutorial/index.org
@@ -278,15 +278,15 @@ mkdir -p ~/enos-myxp
 cd ~/enos-myxp
 #+END_SRC
 
-Then, install EnOS in your working directory:
+Then, install EnOS in your working directory (python3.5+ is required):
 
 #+BEGIN_SRC sh :tangle ../../tests/functionnal/tests/tutorial/enos-node.sh
 # enos:~/enos-myxp$
-virtualenv --python=python2.7 venv
+virtualenv --python=python3 venv
 # (venv) enos:~/enos-myxp$
 . venv/bin/activate
 # (venv) enos:~/enos-myxp$
-pip install "enos[openstack]==4.2.1"
+pip install "enos[openstack]==4.3.0"
 #+END_SRC
 
 #+BEGIN_note

--- a/docs/tutorial/index.rst
+++ b/docs/tutorial/index.rst
@@ -235,7 +235,7 @@ The first step is to determine on which cluster you will deploy
 OpenStack. To that end, you can run ``funk`` (Find yoUr Nodes on g5K)
 from any frontend to see the availability on G5K:
 
-.. code:: sh
+.. code-block:: sh
 
     # laptop:~$
     ssh nantes.g5k
@@ -251,7 +251,7 @@ cluster’s site first, and then, get a new machine which we will use as
 our *enos* node. In this document, we target the parapide cluster,
 located in the Rennes site:
 
-.. code:: sh
+.. code-block:: sh
 
     # fnantes:~$
     ssh rennes
@@ -272,7 +272,7 @@ prompt).
     this session, you can connect to the frontend and attach to your tmux
     session, as follows:
 
-    .. code:: sh
+    .. code-block:: sh
 
         # laptop:~$
         ssh rennes.g5k
@@ -282,23 +282,23 @@ prompt).
 Make a directory from where you will install EnOS and run your
 experiments:
 
-.. code:: sh
+.. code-block:: sh
 
     # enos:~$
     mkdir -p ~/enos-myxp
     # enos:~$
     cd ~/enos-myxp
 
-Then, install EnOS in your working directory:
+Then, install EnOS in your working directory (python3.5+ is required):
 
-.. code:: sh
+.. code-block:: sh
 
     # enos:~/enos-myxp$
-    virtualenv --python=python2.7 venv
+    virtualenv --python=python3 venv
     # (venv) enos:~/enos-myxp$
     . venv/bin/activate
     # (venv) enos:~/enos-myxp$
-    pip install "enos[openstack]==4.2.1"
+    pip install "enos[openstack]==4.3.0"
 
 .. note::
 
@@ -310,7 +310,7 @@ Then, install EnOS in your working directory:
     that if you open a new terminal, you need to re-enter the venv. For
     instance, now that EnOS is installed, you can come back as follow:
 
-    .. code:: sh
+    .. code-block:: sh
 
         # laptop:~$
         ssh rennes.g5k
@@ -394,8 +394,8 @@ this configuration file are interested for a simple use of EnOS:
 
   - Which OpenStack project to enable/disable (*e.g.*, ``enable_heat: "no"``).
 
-.. code:: yaml
-    :number-lines: 1
+.. code-block:: yaml
+    :lineno-start: 1
     :name: lst:reservation.yaml
 
     ---
@@ -477,7 +477,7 @@ Docker container.
 
 Launch the deployment with:
 
-.. code:: sh
+.. code-block:: sh
 
     # (venv) enos:~/enos-myxp$
     enos deploy -f reservation.yaml
@@ -487,7 +487,7 @@ EnOS is now provisioning three machines on the cluster targeted by the
 OpenStack services on them, and you can display information regarding
 your deployment by typing:
 
-.. code:: sh
+.. code-block:: sh
 
     # (venv) enos:~/enos-myxp$
     enos info
@@ -499,7 +499,7 @@ way to speed up your deployment [11]_ ), you can
 observe EnOS running containers on the control node. For that, you can
 access to the control node by typing:
 
-.. code:: sh
+.. code-block:: sh
 
     # (venv) enos:~/enos-myxp$
     ssh -l root $(enos info --out json | jq -r '.rsc.control[0].address')
@@ -515,7 +515,7 @@ access to the control node by typing:
     Note that at the end of your session, you can release your reservation
     by typing:
 
-    .. code:: sh
+    .. code-block:: sh
 
         # (venv) enos:~/enos-myxp$
         enos destroy --hard
@@ -536,7 +536,7 @@ new terminal and type the following:
 
 1. Find the control node address using EnOS:
 
-   .. code:: sh
+   .. code-block:: sh
 
        # (venv) enos:~/enos-myxp$
        enos info
@@ -545,7 +545,7 @@ new terminal and type the following:
 
 2. Create the tunnel from your laptop:
 
-   .. code:: sh
+   .. code-block:: sh
 
        # laptop:~$ -- `ssh -NL 8000:<g5k-control>:80 <g5k-site>.g5k`, e.g.,
        ssh -NL 8000:paravance-14-kavlan-4.nantes.grid5000.fr:80 rennes.g5k
@@ -556,14 +556,14 @@ new terminal and type the following:
     associated to a cluster by consulting the `G5k Cheatsheet <https://www.grid5000.fr/mediawiki/images/G5k_cheat_sheet.pdf>`_. If you are
     concerned, connect to the network node as root with:
 
-    .. code:: sh
+    .. code-block:: sh
 
         # (venv) enos:~/enos-myxp$
         ssh -l root $(enos info --out json | jq -r '.rsc.network[0].address')
 
     And execute the following script:
 
-    .. code:: sh
+    .. code-block:: sh
 
         #!/usr/bin/env bash
 
@@ -630,7 +630,7 @@ credentials each time.
 
 Load the OpenStack credentials:
 
-.. code:: sh
+.. code-block:: sh
 
     # (venv) enos:~/enos-myxp$
     . current/admin-openrc
@@ -639,12 +639,12 @@ You can then check that your environment is correctly set executing
 the following command that should output something similar to the
 listing `lst:env-os`_:
 
-.. code:: sh
+.. code-block:: sh
 
     # (venv) enos:~/enos-myxp$
     env|fgrep OS_|sort
 
-.. code:: sh
+.. code-block:: sh
     :name: lst:env-os
 
     OS_AUTH_URL=http://10.24.61.255:35357/v3
@@ -695,7 +695,7 @@ View VMs logs
 Based on these commands, you can use the CLI to start a new tiny
 cirros VM called ``cli-vm``:
 
-.. code:: sh
+.. code-block:: sh
 
     # (venv) enos:~/enos-myxp$
     openstack server create --image cirros.uec\
@@ -705,7 +705,7 @@ cirros VM called ``cli-vm``:
 
 Then, display the information about your VM with the following command:
 
-.. code:: sh
+.. code-block:: sh
 
     # (venv) enos:~/enos-myxp$
     openstack server show cli-vm
@@ -722,7 +722,7 @@ will find a challenge here: try to ping the VM from the lab machine.
 For the others, you have to manually affect a floating IP to your
 machine if you want it pingable from the enos node.
 
-.. code:: sh
+.. code-block:: sh
 
     # (venv) enos:~/enos-myxp$
     openstack server add floating ip\
@@ -731,7 +731,7 @@ machine if you want it pingable from the enos node.
 
 You can ask for the status of your VM and its IPs with:
 
-.. code:: sh
+.. code-block:: sh
 
     # (venv) enos:~/enos-myxp$
     openstack server show cli-vm -c status -c addresses
@@ -739,7 +739,7 @@ You can ask for the status of your VM and its IPs with:
 Wait one minute or two the time for the VM to boot, and when the state
 is ``ACTIVE``, you can ping it on its floating IP and SSH on it:
 
-.. code:: sh
+.. code-block:: sh
 
     # (venv) enos:~/enos-myxp$
     ping <floating-ip>
@@ -751,7 +751,7 @@ is ``ACTIVE``, you can ping it on its floating IP and SSH on it:
     Waiting for the IP to appear and then ping it could be done with a
     bunch of bash commands, such as in listing `lst:query-ip`_.
 
-    .. code:: sh
+    .. code-block:: sh
         :name: lst:query-ip
 
 
@@ -797,28 +797,28 @@ and Horizon. For instance, list all the features offered by Nova with
 
 1. SSH on ``cli-vm`` using its name rather than its private IP.
 
-   .. code:: sh
+   .. code-block:: sh
 
        # (venv) enos:~/enos-myxp$
        openstack server ssh cli-vm --public --login cirros
 
 2. Create a snapshot of ``cli-vm``.
 
-   .. code:: sh
+   .. code-block:: sh
 
        # (venv) enos:~/enos-myxp$
        nova image-create cli-vm cli-vm-snapshot --poll
 
 3. Delete the ``cli-vm``.
 
-   .. code:: sh
+   .. code-block:: sh
 
        # (venv) enos:~/enos-myxp$
        openstack server delete cli-vm --wait
 
 4. Boot a new machine ``cli-vm-clone`` from the snapshot.
 
-   .. code:: sh
+   .. code-block:: sh
 
        # (venv) enos:~/enos-myxp$
        openstack server create --image cli-vm-snapshot\
@@ -860,7 +860,7 @@ node. As a consequence, prior being able to be reachable from your
 browser, you need to set a tunnel to this service, by typing on your
 laptop:
 
-.. code:: sh
+.. code-block:: sh
 
     # laptop:~$ -- `ssh -NL 3000:<g5k-control>:3000 <g5k-site>.g5k`, e.g.,
     ssh -NL 3000:paravance-14-kavlan-4.nantes.grid5000.fr:3000 nantes.g5k
@@ -876,7 +876,7 @@ The Grafana dashboard is highly customizable. For the sake of
 simplicity, we propose to use our configuration file that you can get
 with:
 
-.. code:: sh
+.. code-block:: sh
 
     # laptop:~$
     curl -O http://enos.irisa.fr/tp-g5k/grafana_dashboard.json
@@ -908,7 +908,7 @@ Shaker [16]_ . And these two are well integrated into EnOS.
 
 EnOS looks inside the ``workload`` directory for a file named ``run.yml``.
 
-.. code:: sh
+.. code-block:: sh
 
     # (venv) enos:~/enos-myxp$
     mkdir -p workload
@@ -931,8 +931,8 @@ with the dedicated ``args`` (l. 12), and thus could be only
 applies to the specific scenario. For instance here, the ``30`` value
 overrides the ``sla_max_avg_duration`` default value solely in the ``boot and list servers`` scenario.
 
-.. code:: yaml
-    :number-lines: 1
+.. code-block:: yaml
+    :lineno-start: 1
     :name: lst:run.yml
 
     ---
@@ -956,7 +956,7 @@ overrides the ``sla_max_avg_duration`` default value solely in the ``boot and li
 
 Calling Rally and Shaker from EnOS is done with:
 
-.. code:: sh
+.. code-block:: sh
 
     # (venv) enos:~/enos-myxp$
     enos bench --workload=workload
@@ -987,7 +987,7 @@ number of iteration and percent of failures, per scenario. These
 reports, plus data measured by cAdvisor and Collectd, plus logs of
 every OpenStack services can be backup by EnOS with:
 
-.. code:: sh
+.. code-block:: sh
 
     # (venv) enos:~/enos-myxp$
     enos backup --backup_dir=benchresults
@@ -1000,7 +1000,7 @@ can extract the Rally report of the *Nova boot and list servers*
 scenario with the following command and then open it in your favorite
 browser:
 
-.. code:: sh
+.. code-block:: sh
 
     # (venv) enos:~/enos-myxp$
     tar --file benchresults/*-rally.tar.gz\
@@ -1025,7 +1025,7 @@ use of groups of nodes. Resources must be described using a ``topology``
 description instead of a ``resources`` description. For instance,
 listings `lst:topos-g5k`_ defines two groups named ``grp1`` and ``grp2``.
 
-.. code:: yaml
+.. code-block:: yaml
     :name: lst:topos-g5k
 
     topology:
@@ -1040,7 +1040,7 @@ listings `lst:topos-g5k`_ defines two groups named ``grp1`` and ``grp2``.
 Constraints are then described under the ``network_constraints`` key in
 the ``reservation.yaml`` file:
 
-.. code:: yaml
+.. code-block:: yaml
     :name: lst:net-constraints
 
     network_constraints:
@@ -1090,7 +1090,7 @@ results in:
 
 Run the Shaker ``dense_l3_east_west`` scenario with
 
-.. code:: sh
+.. code-block:: sh
 
     # (venv) enos:~/enos-myxp$
     enos bench --workload=workload
@@ -1116,14 +1116,14 @@ by updating the ``reservation.yaml`` and add ``enable_neutron_dvr: "yes"``
 under the ``kolla`` key.
 Then, tell EnOS to reconfigure Neutron.
 
-.. code:: sh
+.. code-block:: sh
 
     # (venv) enos:~/enos-myxp$
     enos os --tags=neutron --reconfigure
 
 And finally, re-execute the ``dense_l3_east_west`` scenario.
 
-.. code:: sh
+.. code-block:: sh
 
     # (venv) enos:~/enos-myxp$
     enos bench --workload=workload
@@ -1142,7 +1142,7 @@ GitHub [18]_  and continue to have fun with EnOS.
 8.1 Nova scenario for Rally
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. code:: yaml
+.. code-block:: yaml
 
     {% set image_name = image_name or "cirros.uec" %}
     {% set flavor_name = flavor_name or "m1.tiny" %}
@@ -1187,7 +1187,7 @@ GitHub [18]_  and continue to have fun with EnOS.
 8.2 Configuration file with a topology and network constraints
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. code:: yaml
+.. code-block:: yaml
 
     ---
     # ############################################### #

--- a/enos/ansible/roles/common/tasks/pull.yml
+++ b/enos/ansible/roles/common/tasks/pull.yml
@@ -5,6 +5,7 @@
     state: present
     update_cache: yes
   with_items:
+    - git
     - python-setuptools
     - kvm
     - fping

--- a/enos/provider/chameleonbaremetal.py
+++ b/enos/provider/chameleonbaremetal.py
@@ -1,6 +1,8 @@
 import enos.provider.chameleonkvm as cc
 from enoslib.infra.enos_chameleonbaremetal.provider\
     import Chameleonbaremetal as Ecb
+from enoslib.infra.enos_chameleonbaremetal.configuration\
+    import Configuration
 
 import logging
 
@@ -36,7 +38,8 @@ class Chameleonbaremetal(cc.Chameleonkvm):
     def init(self, conf, force_deploy=False):
         logging.info("Chameleon baremetal provider")
         enoslib_conf = self.build_config(conf)
-        ecb = Ecb(enoslib_conf)
+        _conf = Configuration.from_dictionnary(enoslib_conf)
+        ecb = Ecb(_conf)
         roles, networks = ecb.init(force_deploy=force_deploy)
         return roles, networks
 

--- a/enos/provider/chameleonkvm.py
+++ b/enos/provider/chameleonkvm.py
@@ -1,4 +1,8 @@
 import enos.provider.openstack as openstack
+from enoslib.infra.enos_chameleonkvm.provider import Chameleonkvm as Eckvm
+from enoslib.infra.enos_chameleonkvm.configuration import Configuration
+
+import logging
 
 # - SPHINX_DEFAULT_CONFIG
 DEFAULT_CONFIG = {
@@ -14,7 +18,12 @@ DEFAULT_CONFIG = {
 
 class Chameleonkvm(openstack.Openstack):
     def init(self, conf, force_deploy=False):
-        return super(Chameleonkvm, self).init(conf, force_deploy)
+        logging.info("Chameleonkvm provider")
+        enoslib_conf = self.build_config(conf)
+        _conf = Configuration.from_dictionnary(enoslib_conf)
+        eckvm = Eckvm(_conf)
+        roles, networks = eckvm.init(force_deploy=force_deploy)
+        return roles, networks
 
     def destroy(self, env):
         super(Chameleonkvm, self).destroy(env)

--- a/enos/provider/openstack.py
+++ b/enos/provider/openstack.py
@@ -3,6 +3,7 @@ from enos.utils.constants import NETWORK_INTERFACE
 from enos.utils.extra import gen_enoslib_roles
 from enoslib.api import expand_groups
 from enoslib.infra.enos_openstack.provider import Openstack as Enos_Openstack
+from enoslib.infra.enos_openstack.configuration import Configuration
 
 import logging
 
@@ -46,6 +47,7 @@ DEFAULT_CONFIG = {
 
 def _build_enoslib_conf(conf):
     enoslib_conf = conf.get("provider", {})
+    enoslib_conf.pop("type", None)
     if enoslib_conf.get("resources") is not None:
         return enoslib_conf
 
@@ -55,7 +57,7 @@ def _build_enoslib_conf(conf):
         grps = expand_groups(desc["group"])
         for grp in grps:
             machines.append({
-                "flavor": desc["flavor"],
+                "flavour": desc["flavor"],
                 "roles": [grp, desc["role"]],
                 "number": desc["number"],
             })
@@ -72,7 +74,8 @@ class Openstack(Provider):
     def init(self, conf, force_deploy=False):
         logging.info("Openstack provider")
         enoslib_conf = self.build_config(conf)
-        openstack = Enos_Openstack(enoslib_conf)
+        _conf = Configuration.from_dictionnary(enoslib_conf)
+        openstack = Enos_Openstack(_conf)
         roles, networks = openstack.init(force_deploy=force_deploy)
         return roles, networks
 

--- a/enos/provider/static.py
+++ b/enos/provider/static.py
@@ -4,6 +4,7 @@ import logging
 
 from enoslib.api import expand_groups
 import enoslib.infra.enos_static.provider as enos_static
+from enoslib.infra.enos_static.configuration import Configuration
 
 from enos.provider.provider import Provider
 
@@ -47,6 +48,7 @@ def _gen_enoslib_roles(resources_or_topology):
 def _build_enoslib_conf(config):
     conf = copy.deepcopy(config)
     enoslib_conf = conf.get("provider")
+    enoslib_conf.pop("type", None)
     if enoslib_conf.get("resources") is not None:
         return enoslib_conf
 
@@ -81,7 +83,8 @@ class Static(Provider):
     def init(self, conf, force_deploy=False):
         LOGGER.info("Static provider")
         enoslib_conf = _build_enoslib_conf(conf)
-        static = enos_static.Static(enoslib_conf)
+        _conf = Configuration.from_dictionnary(enoslib_conf)
+        static = enos_static.Static(_conf)
         roles, networks = static.init(force_deploy)
         return roles, networks
 

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     long_description=read('README.rst'),
     packages=find_packages(),
     install_requires=[
-        'enoslib==2.0.0-alpha.1',
+        'enoslib==2.0.0-alpha.2',
         'docopt>=0.6.2,<0.7.0',
         # All kolla commands will run inside a dedicated venv. The version is
         # unspecified since the use of virtualenv is very basic.

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     long_description=read('README.rst'),
     packages=find_packages(),
     install_requires=[
-        'enoslib>=1.12.0,<2.0.0',
+        'enoslib==2.0.0-alpha.1',
         'docopt>=0.6.2,<0.7.0',
         # All kolla commands will run inside a dedicated venv. The version is
         # unspecified since the use of virtualenv is very basic.

--- a/tests/functionnal/tests/chameleon/launch.sh
+++ b/tests/functionnal/tests/chameleon/launch.sh
@@ -16,15 +16,12 @@ cd $SCRIPT_DIR
 # shellcheck disable=SC1091
 . ../utils.sh
 
-virtualenv venv
+virtualenv -p python3 venv
 # shellcheck disable=SC1091
 . venv/bin/activate
 
 pip install -e "$BASE_DIR"
 pip install -e "$BASE_DIR"[openstack]
-#pip install -U git+https://github.com/BeyondTheClouds/enoslib
-pip install -U -e /home/msimonin/workspace/repos/enoslib
-pip install ipdb
 
 # some cleaning
 enos deploy -f $1 # --force-deploy

--- a/tests/functionnal/tests/grid5000/launch.sh
+++ b/tests/functionnal/tests/grid5000/launch.sh
@@ -16,12 +16,11 @@ cd $SCRIPT_DIR
 # shellcheck disable=SC1091
 . ../utils.sh
 
-virtualenv venv
+virtualenv -p python3 venv
 # shellcheck disable=SC1091
 . venv/bin/activate
 
 pip install -e "$BASE_DIR"
-pip install -U git+https://github.com/BeyondTheClouds/enoslib
 
 # some cleaning
 enos deploy -f $1

--- a/tests/functionnal/tests/static/launch.sh
+++ b/tests/functionnal/tests/static/launch.sh
@@ -16,13 +16,11 @@ cd $SCRIPT_DIR
 # shellcheck disable=SC1091
 . ../utils.sh
 
-virtualenv venv
+virtualenv -p python3 venv
 # shellcheck disable=SC1091
 . venv/bin/activate
 
 pip install -e "$BASE_DIR"
-pip install ipdb
-pip install -U git+https://github.com/BeyondTheClouds/enoslib
 
 # some cleaning
 # vagrant destroy -f || true

--- a/tests/functionnal/tests/tutorial/enos-node.sh
+++ b/tests/functionnal/tests/tutorial/enos-node.sh
@@ -1,14 +1,30 @@
+#!/usr/bin/env bash
+# Setup of Functional Test
+#    :PROPERTIES:
+#    :header-args: :tangle ../../tests/functionnal/tests/tutorial/enos-node.sh :noweb yes
+#    :END:
+
+# Every source blocks of this section are going be tangled at the top of
+# the functional test file.
+
+# Set the Shebang, tells to exit immediately if a command exits with a
+# non-zero status, and tells to print commands and their arguments as
+# they are executed.
+
+set -o errexit
+set -o xtrace
 
 
-# Then, install EnOS in your working directory:
+
+# Then, install EnOS in your working directory (python3.5+ is required):
 
 
 # enos:~/enos-myxp$
-virtualenv --python=python2.7 venv
+virtualenv --python=python3 venv
 # (venv) enos:~/enos-myxp$
 . venv/bin/activate
 # (venv) enos:~/enos-myxp$
-pip install "enos[openstack]==4.2.1"
+pip install "enos[openstack]==4.3.0"
 
 # Deploy OpenStack
 # EnOS manages all the aspects of an OpenStack deployment by calling

--- a/tests/functionnal/tests/tutorial/reservation.yaml
+++ b/tests/functionnal/tests/tutorial/reservation.yaml
@@ -23,14 +23,14 @@ inventory: inventories/inventory.sample
 # ############################################### #
 registry:
   type: internal
-  #  ceph: true
-  # ceph_keyring: /home/discovery/.ceph/ceph.client.discovery.keyring
-  # ceph_id: discovery
-  # ceph_rbd: discovery_kolla_registry/datas
-  # ceph_mon_host:
-  #  - ceph0.rennes.grid5000.fr
-  #  - ceph1.rennes.grid5000.fr
-  #  - ceph2.rennes.grid5000.fr
+  ceph: true
+  ceph_keyring: /home/discovery/.ceph/ceph.client.discovery.keyring
+  ceph_id: discovery
+  ceph_rbd: discovery_kolla_registry/datas
+  ceph_mon_host:
+    - ceph0.rennes.grid5000.fr
+    - ceph1.rennes.grid5000.fr
+    - ceph2.rennes.grid5000.fr
 
 # ############################################### #
 # Enos Customizations                             #

--- a/tests/functionnal/tests/tutorial/reservation.yaml
+++ b/tests/functionnal/tests/tutorial/reservation.yaml
@@ -23,14 +23,14 @@ inventory: inventories/inventory.sample
 # ############################################### #
 registry:
   type: internal
-  ceph: true
-  ceph_keyring: /home/discovery/.ceph/ceph.client.discovery.keyring
-  ceph_id: discovery
-  ceph_rbd: discovery_kolla_registry/datas
-  ceph_mon_host:
-    - ceph0.rennes.grid5000.fr
-    - ceph1.rennes.grid5000.fr
-    - ceph2.rennes.grid5000.fr
+  #  ceph: true
+  # ceph_keyring: /home/discovery/.ceph/ceph.client.discovery.keyring
+  # ceph_id: discovery
+  # ceph_rbd: discovery_kolla_registry/datas
+  # ceph_mon_host:
+  #  - ceph0.rennes.grid5000.fr
+  #  - ceph1.rennes.grid5000.fr
+  #  - ceph2.rennes.grid5000.fr
 
 # ############################################### #
 # Enos Customizations                             #

--- a/tests/functionnal/tests/vagrant/launch.sh
+++ b/tests/functionnal/tests/vagrant/launch.sh
@@ -16,7 +16,7 @@ cd $SCRIPT_DIR
 # shellcheck disable=SC1091
 . ../utils.sh
 
-virtualenv venv
+virtualenv -p python3 venv
 # shellcheck disable=SC1091
 . venv/bin/activate
 

--- a/tests/unit/provider/test_g5k.py
+++ b/tests/unit/provider/test_g5k.py
@@ -57,8 +57,8 @@ class TestGenEnoslibRoles(unittest.TestCase):
         networks = sorted(enoslib_conf['resources']['networks'],
                           key=operator.itemgetter('id'))
         self.assertEquals(2, len(networks))
-        self.assertEquals('network_interface', networks[1]['role'])
-        self.assertEquals('neutron_external_interface', networks[0]['role'])
+        self.assertCountEqual(['network_interface'], networks[1]['roles'])
+        self.assertCountEqual(['neutron_external_interface'], networks[0]['roles'])
 
         self.assertEquals('site1', networks[1]['site'])
         self.assertEquals('site1', networks[0]['site'])
@@ -89,7 +89,7 @@ class TestGenEnoslibRoles(unittest.TestCase):
         networks = sorted(enoslib_conf['resources']['networks'],
                           key=operator.itemgetter('id'))
         self.assertEquals(1, len(networks))
-        self.assertEquals('network_interface', networks[0]['role'])
+        self.assertCountEqual(['network_interface'], networks[0]['roles'])
         self.assertEquals('site1', networks[0]['site'])
 
     @mock.patch("enos.provider.g5k._get_sites", return_value={"site1"})

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
-# tox -epy27
+# tox -e py35
 [tox]
 skipsdist = True
-envlist = py27, py35, py36, pep8
+envlist = py35, py36, pep8
 
 [testenv]
 whitelist_externals = make
@@ -48,6 +48,5 @@ max-complexity = 13
 # Instruct travis which envs to run
 [travis]
 python =
-  2.7: py27, pep8
   3.5: py35, pep8
   3.6: py36, pep8


### PR DESCRIPTION
Align the code with future enoslib 2.x.y.
    
Note that this drops py27 support. This patch is minimal in the sense it
only introduce the configuration object from  the existing dictionnary,
in the future we'll probably want to get rid of the intermediate
dictionnary.
    
What I also see
- ceph registry is currently broken (probably due to the ceph cluster migration), we'll need to fix that in a future patch
- git need to be put as mandatory package (not installed on debian9-x64-nfs)

