### PR TITLE
Build the documentation with github actions

### DIFF
--- a/.github/workflows/build-and-publish-doc.yml
+++ b/.github/workflows/build-and-publish-doc.yml
@@ -1,0 +1,38 @@
+name: build & publish doc
+on:
+  push:
+    paths:
+      # Call this action if we change the doc ...
+      - 'docs/**'
+      # ... or if we change the project version
+      - 'pyproject.toml'
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout sources to build the doc
+      uses: actions/checkout@v2
+
+    - name: Get python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+
+    - name: Upgrade pip and install poetry
+      run: |
+        python3 -m pip install --upgrade pip
+        pip install poetry
+
+    - name: Build the documentation
+      run: |
+        poetry install
+        poetry run tox -edocs
+
+    - name: Deploy on gh-pages
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        github_token:  ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: ./docs/_build/html
+        publish_branch: gh-pages

--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-|Build Status| |Documentation Status| |Code style| |License| |Pypi|
+|Build Status| |Pypi| |Code style| |License|
 
 Join us on gitter :  |Join the chat at
 https://gitter.im/BeyondTheClouds/enos|
@@ -27,9 +27,9 @@ Quick Start
 For the quick-start, we will bring up an OpenStack on VirtualBox
 because it is free and works on all major platforms.  Enos can,
 however, work with many testbeds including `Grid'5000
-<https://enos.readthedocs.io/en/stable/provider/grid5000.html>`__ and
+<https://beyondtheclouds.github.io/enos/provider/grid5000.html>`__ and
 `Chameleon
-<https://enos.readthedocs.io/en/stable/provider/openstack.html>`__.
+<https://beyondtheclouds.github.io/enos/provider/openstack.html>`__.
 
 First, make sure your development machine has `VirtualBox
 <https://www.virtualbox.org/>`__ and `Vagrant
@@ -49,10 +49,11 @@ take a while (around 30 minutes to pull and run all OpenStack docker
 images).
 
 You can `customize
-<https://enos.readthedocs.io/en/stable/customization/>`__ the deployed
-services and the number of virtual machines allocated by modifying the
-generated `reservation.yaml` file.  Calls `enos --help` or read the
-`documentation <https://enos.readthedocs.io>`__ for more information.
+<https://beyondtheclouds.github.io/enos/customization/>`__ the
+deployed services and the number of virtual machines allocated by
+modifying the generated ``reservation.yaml`` file.  Calls ``enos
+--help`` or read the `documentation
+<https://beyondtheclouds.github.io/enos/>`__ for more information.
 
 Acknowledgment
 ==============
@@ -64,14 +65,12 @@ Enos is developed in the context of the `Discovery
 Links
 =====
 
--  Docs - https://enos.readthedocs.io
--  Docker - https://hub.docker.com/r/beyondtheclouds/
+-  Docs - https://beyondtheclouds.github.io/enos/
 -  Discovery - https://beyondtheclouds.github.io/
+-  Docker - https://hub.docker.com/r/beyondtheclouds/
 
 .. |Build Status| image:: https://travis-ci.org/BeyondTheClouds/enos.svg?branch=master
    :target: https://travis-ci.org/BeyondTheClouds/enos
-.. |Documentation Status| image:: https://readthedocs.org/projects/enos/badge/?version=stable
-   :target: http://enos.readthedocs.io/en/stable/?badge=stable
 .. |Join the chat at https://gitter.im/BeyondTheClouds/enos| image:: https://badges.gitter.im/BeyondTheClouds/enos.svg
    :target: https://gitter.im/BeyondTheClouds/enos?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge
 .. |Code style| image:: https://api.codacy.com/project/badge/Grade/87536e9c0f0d47e08d1b9e0950c9d14b

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -15,7 +15,7 @@ You may prefer to go with a virtualenv. Please refer to the
 and the rest of this section for further information.
 
 
-Then install enos inside a virtualenv (python3.5+ required):
+Then install enos inside a virtualenv (python3.7+ required):
 
 .. code-block:: bash
 
@@ -35,17 +35,28 @@ Then install enos inside a virtualenv (python3.5+ required):
 Configuration
 -------------
 
-To get started you can get the sample configuration file and edit it:
+To get started you need an Enos configuration file.  Among other
+things, that file tells Enos on which testbed to acquire resources and
+deploy OpenStack.  Enos supports many testbeds including Vagrant,
+Grid'5000, Chameleon and more generally any OpenStack cloud.
+
+The configuration may vary from one testbed to another.  For this
+quick-start, we will bring up an OpenStack on Vagrant/VirtualBox
+because it is free and works on all major platforms.  Please, refer to
+the dedicated :ref:`provider` section for the full list of supported
+testbed.
+
+First, make sure you have `VirtualBox <https://www.virtualbox.org/>`__
+and `Vagrant <https://www.vagrantup.com/downloads>`__ installed. Then,
+generate the configuration file with:
 
 .. parsed-literal::
 
-    $ enos new > reservation.yaml
-    $ <editor> reservation.yaml
+    (venv) $ enos new --provider=vagrant:virtualbox
 
-
-The configuration may vary from one provider to another, please refer to the
-dedicated :ref:`provider` configuration
-
+This generates a ``reservation.yaml`` file in the current directory.
+This file shows available configuration options (and their defaults in
+comments).  Take the time to review that file before going further.
 
 .. note::
 
@@ -65,19 +76,19 @@ Once your configuration is done, you can launch the deployment:
 
 The deployment is the combination of the following three phases:
 
-1. Acquire the raw resources that are necessary for the deployment of
+1. Acquire the resources that are necessary for the deployment of
    OpenStack. Enos acquires resources according to the ``provider``
-   and ``resources`` information in the reservation file. One can
+   and ``resources`` information in the configuration file. One can
    perform this phase by calling ``enos up``.
 
-2. Deploy OpenStack to the resources acquired during the previous
+2. Deploy OpenStack on the resources acquired during the previous
    phase. Enos uses the resource list provided by the previous phase
    and combines it with the information specified in the file targeted
    by the ``inventory`` key to produce a file that gives a mapping of
    which OpenStack services have to be deployed to which resources.
-   Enos then calls the Kolla-Ansible tool with this file to deploy the
-   containerized OpenStack services to the right resources. One
-   can perform this phase by calling ``enos os``.
+   Enos then calls the Kolla Ansible tool with this file to deploy the
+   containerized OpenStack services to the right resources. One can
+   perform this phase by calling ``enos os``.
 
    .. note::
 

--- a/docs/provider/grid5000.rst
+++ b/docs/provider/grid5000.rst
@@ -3,66 +3,61 @@
 Grid'5000
 =========
 
-
-Installation
-------------
-
-Connect to a Grid'5000 frontend of your choice. Then, refer to the
-:ref:`installation` section to install Enos.
-
-To access the Grid'5000 API, you must configure
-`python-grid5000 <https://pypi.org/project/python-grid5000/>`_. Please refer to
-the corresponding documentation
-
-If the `virtualenv` module is missing:
-
-.. code-block:: bash
-
-    $ pip install virtualenv --user     # Install virtualenv
-    $ export PATH=~/.local/bin/:${PATH} # Put it into your path
-
-
-Basic configuration
--------------------
-
-The provider relies on cluster names to group the wanted resources. For example
-the following is a valid resources description:
-
-.. literalinclude:: ../../tests/functionnal/tests/grid5000/basic-00.yaml
-   :language: yaml
-   :linenos:
-
-
-Deployment
+Quick start
 -----------
 
-We suggest you to run the deployment from a dedicated node (especially for large
-deployment). For now the recommended way to do so is to reserve one node prior
-of your reservation. In the case of an interactive deployment:
+To access the Grid'5000 API, you must configure `python-grid5000
+<https://pypi.org/project/python-grid5000/>`_.  Roughly there is two
+possibilities.  First, when you access to Grid'5000 from outside of it
+(e.g from your local workstation). In such a case, you need to specify
+the following configuration file:
 
 .. code-block:: bash
 
-    frontend$ oarsub -I -l 'walltime=2:00:00'
-    node$ source venv/bin/activate
-    node$ <edit configuration>
-    node$ enos deploy
+    $ echo '
+    username: MYLOGIN
+    password: MYPASSWORD
+    ' > ~/.python-grid5000.yaml
+    $ chmod 600 ~/.python-grid5000.yaml
+
+Second, when you access to the API from inside Grid’5000 (e.g., a
+Grid'5000 frontend). In such case, providing the username and password
+is unnecessary.  The python-grid5000 lib only need to deal with SSL
+verification by specifying the path to the certificate to use:
+
+.. code-block:: bash
+
+    $ echo '
+    verify_ssl: /etc/ssl/certs/ca-certificates.crt
+    ' > ~/.python-grid5000.yaml
 
 .. note::
 
-   You'll need to configure the access to the Grid'5000 API by setting the following
-   in your ``~/.execo.conf.py`` :
+  You may want to refer to the installation section of python-grid5000
+  library to correctly configure your Grid'5000 connection
+  information. See https://pypi.org/project/python-grid5000/
 
-  .. code-block:: python
-
-      # ~/.execo.conf.py
-      g5k_configuration = {
-          'api_username': "your username",
-          'api_verify_ssl_cert': False
-      }
+After that, ask Enos to create a new ``reservation.yaml`` file with
+the provider ``g5k``. Then review the information in the file
+(especially, the walltime and cluster names for resources). And you
+are ready for the deployment of OpenStack.
 
 
-Default provider configuration
--------------------------------
+.. code-block:: bash
+
+    $ enos new --provider=g5k
+    $ <editor> reservation.yaml  # optional
+    $ enos deploy
+
+
+.. note::
+
+   On Grid'5000, we recommend to install Enos in a virtual
+   environment.  Refer to the :ref:`installation` section for more
+   information.
+
+Provider configuration
+----------------------
 
 The provider comes with the following default options:
 
@@ -73,20 +68,8 @@ The provider comes with the following default options:
 
 They can be overriden in the configuration file.
 
-
-Advanced Configuration
-----------------------
-
-The following is equivalent to the basic configuration but allows for a finer
-grained definition of the resources and associated roles.
-
-.. literalinclude:: ../../tests/functionnal/tests/grid5000/advanced-00.yaml
-   :language: yaml
-   :linenos:
-
-
 Reservation
------------
+^^^^^^^^^^^
 
 In order to reserve in advance the ressources needed by your deployment you can
 set the ``reservation`` key to the desired start date. And launch ``enos
@@ -108,6 +91,44 @@ reservation is done) and relaunch it later with the exact same configuration
 file. For this purpose you can leverage the ``-f`` options of EnOS.
 
 
+Basic complete example
+^^^^^^^^^^^^^^^^^^^^^^
+
+The provider relies on cluster names to group the wanted resources. For example
+the following is a valid resources description:
+
+.. literalinclude:: ../../tests/functionnal/tests/grid5000/basic-00.yaml
+   :language: yaml
+   :linenos:
+
+
+Deployment from a Grid'5000 node
+--------------------------------
+
+If you want to run the deployment from within Grid'5000, we suggest
+you to run the deployment from a dedicated node (especially for large
+deployment). For now the recommended way to do so is to reserve one
+node prior to your reservation. In the case of an interactive
+deployment:
+
+.. code-block:: bash
+
+    frontend$ oarsub -I -l 'walltime=2:00:00'
+    node$ source venv/bin/activate
+    node$ <edit configuration>
+    node$ enos deploy
+
+Advanced example
+----------------
+
+The following is equivalent to the basic configuration but allows for a finer
+grained definition of the resources and associated roles.
+
+.. literalinclude:: ../../tests/functionnal/tests/grid5000/advanced-00.yaml
+   :language: yaml
+   :linenos:
+
+
 Building an Environment
 -----------------------
 
@@ -126,11 +147,11 @@ to finish the registration of the new environment.
 Once the environment is registered in the database, the name of this environment
 can be used in the EnOS configuration replacing the default one. For example,
 let's suppose we want to use a personalised environment named
-``enos-debian9-x64-openstack``, then the configuration can be set as follows:
+``enos-debian10-x64-openstack``, then the configuration can be set as follows:
 
 .. code-block:: yaml
 
    provider:
      type: g5k
-     env_name: enos-debian9-x64-openstack
+     env_name: enos-debian10-x64-openstack
      ...

--- a/docs/provider/static.rst
+++ b/docs/provider/static.rst
@@ -9,7 +9,13 @@ deploy OpenStack on.
 Installation
 ------------
 
-Refer to the :ref:`installation` section to install Enos.
+Refer to the :ref:`installation` section to install Enos. Then do:
+
+.. code-block:: bash
+
+    $ enos new --provider=static
+    $ enos deploy
+
 
 Configuration
 -------------

--- a/docs/provider/vagrant.rst
+++ b/docs/provider/vagrant.rst
@@ -10,16 +10,35 @@ To get started with the vagrant provider, you need to install
 
 * `Vagrant <https://www.vagrantup.com/>`_
 
-You'll also need a virtualization backend. EnOS supports both Virtualbox and
-Libvirt as shown below.
+You'll also need a virtualization backend. EnOS supports both
+VirtualBox and Libvirt as shown below.
 
-Then, refer to the :ref:`installation` section to install Enos.
+Refer to the :ref:`installation` section to install Enos. Then asks
+Enos to create a new ``reservation.yaml`` file with the provider
+``vagrant`` and one of the virtualization technology ``virtualbox`` or
+``libvirt``. Then review the information in the file, and you are
+ready for the deployment of OpenStack.
 
-Basic Configuration
--------------------
+.. code-block:: bash
 
-The provider relies on virtual machine sizes to group the wanted resources. For
-example the following is a valid configuration
+    $ enos new --provider=vagrant:virtualbox  # or --provider=vagrant:libvirt
+    $ <editor> reservation.yaml               # optional
+    $ enos deploy
+
+
+Provider configuration
+----------------------
+
+The provider comes with the following default options:
+
+.. literalinclude:: ../../enos/provider/enos_vagrant.py
+   :start-after: # - SPHINX_DEFAULT_CONFIG
+   :end-before: # + SPHINX_DEFAULT_CONFIG
+
+
+The provider relies on virtual machine sizes to group the wanted
+resources. For example the following is a valid configuration
+
 
 .. literalinclude:: ../../tests/functionnal/tests/vagrant/basic_vbox.yaml
    :language: yaml
@@ -28,8 +47,8 @@ example the following is a valid configuration
 The list of the sizes may be found :enos_src:`here
 <https://gitlab.inria.fr/discovery/enoslib/blob/master/enoslib/infra/enos_vagrant/constants.py#L23-48>`.
 
-By default virtualbox will be used. See below to learn how to change the default
-virtualbox backend.
+By default VirtualBox will be used. See below to learn how to change
+for libvirt.
 
 Use libvirt as the backend for Vagrant
 --------------------------------------
@@ -51,13 +70,6 @@ grained definition of the resources and associated roles.
    :language: yaml
    :linenos:
 
-Default Configuration
----------------------
-
-.. literalinclude:: ../../enos/provider/enos_vagrant.py
-   :start-after: # - SPHINX_DEFAULT_CONFIG
-   :end-before: # + SPHINX_DEFAULT_CONFIG
-
 Build a Box
 -----------
 
@@ -71,8 +83,8 @@ the following commands to register a box named ``personal/enos-box-openstack``:
 
 .. code-block:: bash
 
-   > vagrant package
-   > vagrant box add package.box --name personal/enos-box-openstack
+   $ vagrant package
+   $ vagrant box add package.box --name personal/enos-box-openstack
 
 
 Once the box is registed in the vagrant catalog, the name of this box can be

--- a/docs/tutorial/grid5000-tuto.org
+++ b/docs/tutorial/grid5000-tuto.org
@@ -1254,7 +1254,7 @@ elisp code.
 * Footnotes
 [fn:openstack] https://www.openstack.org/
 [fn:enos-paper] https://hal.inria.fr/hal-01415522v2
-[fn:enos-website] https://enos.readthedocs.io/en/stable/
+[fn:enos-website] https://beyondtheclouds.github.io/enos/
 
 [fn:os-ansible] https://github.com/openstack/openstack-ansible
 [fn:os-chef] https://github.com/openstack/openstack-chef-repo
@@ -1264,8 +1264,8 @@ elisp code.
 
 [fn:oarwalltime] https://www.grid5000.fr/mediawiki/index.php/Advanced_OAR#Changing_the_walltime_of_a_running_job
 
-[fn:enos-provider] [[https://enos.readthedocs.io/en/stable/provider/index.html]]
-[fn:enos-internal-registry] https://enos.readthedocs.io/en/stable/customization/index.html#internal-registry
+[fn:enos-provider] [[https://beyondtheclouds.github.io/enos/provider/]]
+[fn:enos-internal-registry] https://beyondtheclouds.github.io/enos/customization/index.html#internal-registry
 
 [fn:cadvisor] https://github.com/google/cadvisor
 [fn:collectd] https://collectd.org/

--- a/docs/tutorial/grid5000-tuto.rst
+++ b/docs/tutorial/grid5000-tuto.rst
@@ -1252,7 +1252,7 @@ GitHub [17]_  and continue to have fun with EnOS.
 
 .. [2] `https://hal.inria.fr/hal-01415522v2 <https://hal.inria.fr/hal-01415522v2>`_
 
-.. [3] `https://enos.readthedocs.io/en/stable/ <https://enos.readthedocs.io/en/stable/>`_
+.. [3] `https://beyondtheclouds.github.io/enos/ <https://beyondtheclouds.github.io/enos/>`_
 
 .. [4] `https://github.com/openstack/openstack-ansible <https://github.com/openstack/openstack-ansible>`_
 
@@ -1266,7 +1266,7 @@ GitHub [17]_  and continue to have fun with EnOS.
 
 .. [9] `https://www.grid5000.fr/mediawiki/index.php/Advanced_OAR#Changing_the_walltime_of_a_running_job <https://www.grid5000.fr/mediawiki/index.php/Advanced_OAR#Changing_the_walltime_of_a_running_job>`_
 
-.. [10] `https://enos.readthedocs.io/en/stable/provider/index.html <https://enos.readthedocs.io/en/stable/provider/index.html>`_
+.. [10] `https://beyondtheclouds.github.io/enos/provider/ <https://beyondtheclouds.github.io/enos/provider/>`_
 
 .. [11] `https://github.com/google/cadvisor <https://github.com/google/cadvisor>`_
 

--- a/enos/cli.py
+++ b/enos/cli.py
@@ -215,7 +215,7 @@ def new(**kwargs):
             f'You are now ready to deploy OpenStack on {provider} with '
             '`enos deploy`.  Please read comments in the reservation.yaml '
             'as well as the documentation on '
-            f'https://enos.readthedocs.io/en/v{C.VERSION}/ '
+            f'https://beyondtheclouds.github.io/enos/ '
             'for more information on using enos.'))
     except FileExistsError:
         logger.error(textwrap.fill(

--- a/enos/provider/enos_vagrant.py
+++ b/enos/provider/enos_vagrant.py
@@ -10,10 +10,10 @@ from enoslib.service.netem.netem import expand_groups
 
 # - SPHINX_DEFAULT_CONFIG
 DEFAULT_CONFIG = {
-    'type': 'vagrant',
-    'backend': 'virtualbox',
-    'box': 'generic/debian10',
-    'user': 'root',
+    'type': 'vagrant',          # Name of the provider
+    'backend': 'virtualbox',    # Name of the virtualization technology
+    'box': 'generic/debian10',  # Box -- https://app.vagrantup.com/boxes/search
+    'user': 'root',             # SSH user
 }
 # + SPHINX_DEFAULT_CONFIG
 

--- a/enos/provider/g5k.py
+++ b/enos/provider/g5k.py
@@ -19,7 +19,7 @@ DEFAULT_CONFIG = {
     'type': 'g5k',                   # Name of the provider
     'job_name': 'enos',              # Job name in oarstat/gant
     'walltime': '02:00:00',          # Reservation duration time
-    'env_name': 'debian10-x64-min',  # Environment to deploy
+    'env_name': 'debian10-x64-min',  # Environment to deploy (see `kaenv3 -l`)
     'reservation': '',               # Reservation date
     'job_type': 'deploy',            # deploy, besteffort, ...
     'queue': 'default'               # default, production, testing

--- a/enos/tasks/new.py
+++ b/enos/tasks/new.py
@@ -23,8 +23,8 @@ OS_RSC = {'<set a flavor (see `openstack flavor list`)>':
           {'compute': 1, 'network': 1, 'control': 1}}
 VMONG5K_RSC = {'paravance': {'compute': 1, 'network': 1, 'control': 1}}
 STATIC_RSC = (
-    f'<refer to the doc https://enos.readthedocs.io/en/v{C.VERSION}/'
-    'provider/static.html>')
+    '<refer to the doc at '
+    'https://beyondtheclouds.github.io/enos/provider/static.html>')
 
 # Registry definitions
 INTERNAL_REG = {'type': 'internal', 'port': 4000}
@@ -132,5 +132,4 @@ def new(provider_name: str, output_path: Path):
             provider=dump(provider_conf, provider_required_keys),
             resources=yaml.dump(resources_conf),
             registry=yaml.dump(registry_conf),
-            kolla_ansible=kolla.KOLLA_PKG,
-            enos_version=C.VERSION))
+            kolla_ansible=kolla.KOLLA_PKG))

--- a/enos/templates/reservation.yaml.j2
+++ b/enos/templates/reservation.yaml.j2
@@ -5,7 +5,7 @@
 # Testbed targeted for the experiment and its resources.  Each
 # provider comes with specific options and a specific nomenclature for
 # resources.  Refer to the doc of each provider for more information.
-# See https://enos.readthedocs.io/en/v{{ enos_version }}/provider/
+# See https://beyondtheclouds.github.io/enos/provider/
 #
 # Depending on the provider, this part may contain required contents
 # (marked as `<...>`).  In such a case, replace each <...> with a
@@ -31,27 +31,27 @@ resources:
 #   registry:
 #	    type: none
 #
-# See https://enos.readthedocs.io/en/v{{ enos_version }}/customization/index.html#docker-registry-mirror-configuration
+# See https://beyondtheclouds.github.io/enos/customization/index.html#docker-registry-mirror-configuration
 #
 registry:
   {{ registry | indent(2) }}
 
 # Deploy a monitoring stack made of cAdvisor, collectd, influxDB and
 # Graphana.
-# See https://enos.readthedocs.io/en/v{{ enos_version }}/analysis/
+# See https://beyondtheclouds.github.io/enos/analysis/
 #
 # enable_monitoring: no
 
 
 # kolla-ansible executable (could be a PyPi package, a git
 # repository, a local directory ...)
-# See https://enos.readthedocs.io/en/v{{ enos_version }}/customization/index.html#changing-kolla-version
+# See https://beyondtheclouds.github.io/enos/customization/index.html#changing-kolla-version
 #
 # kolla-ansible: {{ kolla_ansible }}
 
 
 # Custom kolla-ansible parameters (as in `globals.yml`)
-# See https://enos.readthedocs.io/en/v{{ enos_version }}/customization/index.html#customize-kolla-variables
+# See https://beyondtheclouds.github.io/enos/customization/index.html#customize-kolla-variables
 #
 # kolla:
 #   kolla_base_distro: "centos"
@@ -61,6 +61,6 @@ registry:
 
 # Kolla-Ansible inventory file that defines on which of the
 # `resources` nodes to deploy OpenStack services.
-# See https://enos.readthedocs.io/en/v{{ enos_version }}/customization/index.html#changing-the-topology
+# See https://beyondtheclouds.github.io/enos/customization/index.html#changing-the-topology
 #
 # inventory: inventory.sample

--- a/enos/utils/errors.py
+++ b/enos/utils/errors.py
@@ -1,5 +1,4 @@
 import textwrap
-import enos.utils.constants as C
 
 
 class EnosError(Exception):
@@ -27,7 +26,7 @@ class EnosUnknownProvider(EnosError):
         super(self.__class__, self).__init__(textwrap.dedent(f''' \
           The provider '{provider_name}' could not be found.
 
-          Please refer to https://enos.readthedocs.io/en/v{C.VERSION}/provider/
+          Please refer to https://beyondtheclouds.github.io/enos/provider/
           to use a provider that exists.
         '''))
         self.provider_name = provider_name

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["Didier Iscovery <discovery-dev@inria.fr>"]
 license = "GPL-3.0-or-later"
 readme = "README.rst"
 homepage = "https://github.com/BeyondTheClouds/enos"
-documentation = "https://enos.readthedocs.io/en/stable/"
+documentation = "https://beyondtheclouds.github.io/enos/"
 keywords = ["OpenStack", "Evaluation", "Grid'5000", "Chameleon", "Vagrant"]
 classifiers = [
   'Development Status :: 4 - Beta',
@@ -28,7 +28,7 @@ include = [
 
 [tool.poetry.dependencies]
 python = "^3.7"
-enoslib = { version = "~5.6", extras = [ "chameleon" ] } 
+enoslib = { version = "~5.6", extras = [ "chameleon" ] }
 # enoslib = { path = '../enoslib', develop = true, extras = [ "chameleon" ]  }
 docopt = ">=0.6.2,<0.7.0"
 virtualenv = "^20.4.3"
@@ -37,14 +37,13 @@ python-heatclient = "^2.3.0"
 influxdb = { version = "4.0.0", optional = true }
 
 [tool.poetry.extras]
-# poetry install -E annotations 
+# poetry install -E annotations
 annotations = ["influxdb"]
 
 [tool.poetry.scripts]
 enos = "enos.cli:main"
 
 [tool.poetry.dev-dependencies]
-GitPython = ">=2.1.5"
 isort = "^5.7.0"
 ipdb = "^0.13.7"
 tox = "^3.23.0"
@@ -52,6 +51,8 @@ pytest = "^6.2.3"
 flake8 = "^3.9.0"
 mock = "^4.0.3"
 ddt = "^1.4.2"
+# doc
+GitPython = ">=2.1.5"
 Sphinx = "^3.5.3"
 sphinx-autobuild = "^2021.3.14"
 sphinx-rtd-theme = "^0.5.2"

--- a/tests/functionnal/tests/packaging/files/motd.sh
+++ b/tests/functionnal/tests/packaging/files/motd.sh
@@ -4,15 +4,15 @@ cat << EOF > /etc/motd
 
 ██╗      ███████╗███╗   ██╗ ██████╗ ███████╗      ██╗
 ╚██╗     ██╔════╝████╗  ██║██╔═══██╗██╔════╝     ██╔╝
- ╚██╗    █████╗  ██╔██╗ ██║██║   ██║███████╗    ██╔╝ 
- ██╔╝    ██╔══╝  ██║╚██╗██║██║   ██║╚════██║    ╚██╗ 
+ ╚██╗    █████╗  ██╔██╗ ██║██║   ██║███████╗    ██╔╝
+ ██╔╝    ██╔══╝  ██║╚██╗██║██║   ██║╚════██║    ╚██╗
 ██╔╝     ███████╗██║ ╚████║╚██████╔╝███████║     ╚██╗
 ╚═╝      ╚══════╝╚═╝  ╚═══╝ ╚═════╝ ╚══════╝      ╚═╝
 
 Experimental eNvironment for OpenStack
 
 ---
-Docs      - https://enos.readthedocs.io
+Docs      - https://beyondtheclouds.github.io/enos/
 Docker    - https://hub.docker.com/r/beyondtheclouds/
 Discovery - https://beyondtheclouds.github.io/
 Source    - https://github.com/BeyondTheClouds/enos

--- a/tests/functionnal/tests/packaging/scripts/motd.sh
+++ b/tests/functionnal/tests/packaging/scripts/motd.sh
@@ -4,15 +4,15 @@ cat << EOF > /etc/motd
 
 ██╗      ███████╗███╗   ██╗ ██████╗ ███████╗      ██╗
 ╚██╗     ██╔════╝████╗  ██║██╔═══██╗██╔════╝     ██╔╝
- ╚██╗    █████╗  ██╔██╗ ██║██║   ██║███████╗    ██╔╝ 
- ██╔╝    ██╔══╝  ██║╚██╗██║██║   ██║╚════██║    ╚██╗ 
+ ╚██╗    █████╗  ██╔██╗ ██║██║   ██║███████╗    ██╔╝
+ ██╔╝    ██╔══╝  ██║╚██╗██║██║   ██║╚════██║    ╚██╗
 ██╔╝     ███████╗██║ ╚████║╚██████╔╝███████║     ╚██╗
 ╚═╝      ╚══════╝╚═╝  ╚═══╝ ╚═════╝ ╚══════╝      ╚═╝
 
 Experimental eNvironment for OpenStack
 
 ---
-Docs      - https://enos.readthedocs.io
+Docs      - https://beyondtheclouds.github.io/enos/
 Docker    - https://hub.docker.com/r/beyondtheclouds/
 Discovery - https://beyondtheclouds.github.io/
 Source    - https://github.com/BeyondTheClouds/enos

--- a/tests/functionnal/tests/tutorial/enos-node.sh
+++ b/tests/functionnal/tests/tutorial/enos-node.sh
@@ -1,22 +1,19 @@
 #!/usr/bin/env bash
 # Setup of Functional Test
-#    :PROPERTIES:
-#    :header-args: :tangle ../../tests/functionnal/tests/tutorial/enos-node.sh :noweb yes
-#    :END:
-
 # Every source blocks of this section are going be tangled at the top of
 # the functional test file.
 
 # Set the Shebang, tells to exit immediately if a command exits with a
 # non-zero status, and tells to print commands and their arguments as
 # they are executed.
+# #+HEADER: :tangle ../../tests/functionnal/tests/tutorial/enos-node.sh :noweb yes
 
 set -o errexit
 set -o xtrace
 
 
 
-# Then, install EnOS in your working directory (python3.5+ is required):
+# Then, install EnOS in your working directory (python3.7+ is required):
 
 
 # enos:~/enos-myxp$
@@ -24,7 +21,7 @@ virtualenv --python=python3 venv
 # (venv) enos:~/enos-myxp$
 . venv/bin/activate
 # (venv) enos:~/enos-myxp$
-pip install "enos[openstack]==6.0.0"
+pip install "enos[openstack]~=7.0.0"
 
 # Deploy OpenStack
 # EnOS manages all the aspects of an OpenStack deployment by calling
@@ -50,10 +47,10 @@ enos deploy -f reservation.yaml
 # new terminal and type the following:
 # 1. Find the control node address using EnOS:
 
-# (venv) enos:~/enos-myxp$
-enos info
-# (venv) enos:~/enos-myxp$
-enos info --out json | jq -r '.rsc.control[0].address'
+   # (venv) enos:~/enos-myxp$
+   enos info
+   # (venv) enos:~/enos-myxp$
+   enos info --out json | jq -r '.rsc.control[0].address'
 
 # Unleash the Operator in You
 # OpenStack provides a command line interface to operate your Cloud. But
@@ -208,30 +205,30 @@ fi
 # ~openstack server --help~. Here are some commands:
 # 1. SSH on ~cli-vm~ using its name rather than its private IP.
 
-# (venv) enos:~/enos-myxp$
-openstack server ssh cli-vm --public --login cirros --option 'BatchMode=yes' --identity ./donatello.pem < ./test-donatello.sh
+   # (venv) enos:~/enos-myxp$
+   openstack server ssh cli-vm --public --login cirros --option 'BatchMode=yes' --identity ./donatello.pem < ./test-donatello.sh
 
 
 # 2. Create a snapshot of ~cli-vm~.
 
-# (venv) enos:~/enos-myxp$
-nova image-create cli-vm cli-vm-snapshot --poll
+   # (venv) enos:~/enos-myxp$
+   nova image-create cli-vm cli-vm-snapshot --poll
 
 
 # 3. Delete the ~cli-vm~.
 
-# (venv) enos:~/enos-myxp$
-openstack server delete cli-vm --wait
+   # (venv) enos:~/enos-myxp$
+   openstack server delete cli-vm --wait
 
 
 # 4. Boot a new machine ~cli-vm-clone~ from the snapshot.
 
-# (venv) enos:~/enos-myxp$
-openstack server create --image cli-vm-snapshot\
-                        --flavor m1.tiny\
-                        --network private\
-                        --wait\
-                        cli-vm-clone
+   # (venv) enos:~/enos-myxp$
+   openstack server create --image cli-vm-snapshot\
+                           --flavor m1.tiny\
+                           --network private\
+                           --wait\
+                           cli-vm-clone
 
 # Benchmark OpenStack
 # Stressing a Cloud manager can be done at two levels: at the /control

--- a/tests/functionnal/tests/tutorial/reservation-topo.yaml
+++ b/tests/functionnal/tests/tutorial/reservation-topo.yaml
@@ -32,21 +32,15 @@ network_constraints:
 # ############################################### #
 # Inventory to use                                #
 # ############################################### #
-inventory: inventories/inventory.sample
+inventory: resources/inventory.sample
 
 # ############################################### #
 # docker registry parameters
 # ############################################### #
 registry:
-  type: internal
-  ceph: true
-  ceph_keyring: /home/discovery/.ceph/ceph.client.discovery.keyring
-  ceph_id: discovery
-  ceph_rbd: discovery_kolla_registry/datas
-  ceph_mon_host:
-    - ceph0.rennes.grid5000.fr
-    - ceph1.rennes.grid5000.fr
-    - ceph2.rennes.grid5000.fr
+  type: external
+  ip: docker-cache.grid5000.fr
+  port: 80
 
 # ############################################### #
 # Enos Customizations                             #
@@ -56,11 +50,10 @@ enable_monitoring: yes
 # ############################################### #
 # Kolla parameters                                #
 # ############################################### #
-kolla_repo: "https://git.openstack.org/openstack/kolla-ansible"
-kolla_ref: "stable/stein"
+kolla-ansible: kolla-ansible~=10.0
 
 # Vars : kolla_repo/ansible/group_vars/all.yml
 kolla:
   kolla_base_distro: "centos"
   kolla_install_type: "source"
-  enable_heat: "yes"
+  enable_heat: yes

--- a/tests/functionnal/tests/tutorial/reservation.yaml
+++ b/tests/functionnal/tests/tutorial/reservation.yaml
@@ -2,12 +2,12 @@
 # ############################################### #
 # Grid'5000 reservation parameters                #
 # ############################################### #
-provider:                     
+provider:
   type: g5k
   job_name: 'enos'
   walltime: '04:00:00'
 
-resources:                    
+resources:
   paravance:
     compute: 1
     network: 1
@@ -16,21 +16,15 @@ resources:
 # ############################################### #
 # Inventory to use                                #
 # ############################################### #
-inventory: inventories/inventory.sample
+inventory: resources/inventory.sample
 
 # ############################################### #
 # docker registry parameters
 # ############################################### #
 registry:
-  type: internal
-  ceph: true
-  ceph_keyring: /home/discovery/.ceph/ceph.client.discovery.keyring
-  ceph_id: discovery
-  ceph_rbd: discovery_kolla_registry/datas
-  ceph_mon_host:
-    - ceph0.rennes.grid5000.fr
-    - ceph1.rennes.grid5000.fr
-    - ceph2.rennes.grid5000.fr
+   type: external
+   ip: docker-cache.grid5000.fr
+   port: 80
 
 # ############################################### #
 # Enos Customizations                             #
@@ -40,11 +34,10 @@ enable_monitoring: yes
 # ############################################### #
 # Kolla parameters                                #
 # ############################################### #
-kolla_repo: "https://git.openstack.org/openstack/kolla-ansible" 
-kolla_ref: "stable/stein"
+kolla-ansible: kolla-ansible~=10.0
 
 # Vars : kolla_repo/ansible/group_vars/all.yml
 kolla:
   kolla_base_distro: "centos"
   kolla_install_type: "source"
-  enable_heat: "yes"
+  enable_heat: yes

--- a/tests/functionnal/tests/tutorial/workload/run.yml
+++ b/tests/functionnal/tests/tutorial/workload/run.yml
@@ -1,18 +1,18 @@
 ---
-rally:                                   
+rally:
     enabled: yes
-    args:                                
-      concurrency:                       
+    args:
+      concurrency:
         - 5
-      times:                             
+      times:
         - 10
-    scenarios:                           
+    scenarios:
       - name: boot and list servers
         file: nova-boot-list-cc.yml
-        args:                            
+        args:
           sla_max_avg_duration: 30
 shaker:
-  enabled: yes                           
+  enabled: yes
   scenarios:
     - name: OpenStack L3 East-West Dense
       file: openstack/dense_l3_east_west


### PR DESCRIPTION
Change the build of the documentation from readthedocs.io to github actions. This change is motivated by the inability of the readthedocs builder to call poetry to build the doc.

As a nice side effect, the doc is now pushed to https://beyondtheclouds.github.io/enos/ which is consistent with the discovery website.  Unfortunately, we now only build the documentation of the latest version.  This removes the ability to browse older versions of the documentation.