### PR TITLE
Fix Docker registry mirror configuration

### DIFF
--- a/enos/cli.py
+++ b/enos/cli.py
@@ -617,7 +617,7 @@ def enos_help(**kwargs):
     if cmd:  # `enos help <cmd>`
         print(textwrap.dedent(_get_cmd_func(cmd).__doc__ or ""))
     else:    # `enos help`
-        print(textwrap.dedent(__doc__))
+        print(textwrap.dedent(__doc__ or ""))
 
 
 # Registry of enos commands (indexed by their name)
@@ -730,7 +730,9 @@ def main():
     # cli_args =
     #  {'--help': False, '--quiet': False, '--verbose': 2, '--version': False,
     #   '<command>': 'help','<args>': ['new'], }
-    enos_global_args = docopt(__doc__, version=C.VERSION, options_first=True,)
+    enos_global_args = docopt(__doc__ or "",
+                              version=C.VERSION,
+                              options_first=True,)
 
     # Set the logging level
     _set_logging_level(

--- a/enos/services/kolla.py
+++ b/enos/services/kolla.py
@@ -343,7 +343,10 @@ class KollaAnsible(object):
             yaml.local_action(
                 **title(f'Install {pip_package} in {venv}'),
                 module="pip",
-                name=[ANSIBLE_PKG, 'influxdb', pip_package],
+                # Pin Jinja2 version to fix the renaming of `contextfilter`
+                # into `pass_context.evalcontextfilter`.
+                # See https://github.com/BeyondTheClouds/enos/pull/346#issuecomment-1080851796
+                name=[ANSIBLE_PKG, 'influxdb', 'Jinja2==3.0.3', pip_package],
                 virtualenv=str(venv),
                 virtualenv_python=PY_VERSION)
 

--- a/enos/tasks/up.py
+++ b/enos/tasks/up.py
@@ -132,6 +132,10 @@ def up(env: elib.Environment,
                              registry_opts={
                                  'type': 'internal',
                                  'port': docker_port})
+    else:
+        error_msg = (f"Docker registry mirror of type \"{docker_type}\" "
+                     "is not supported")
+        raise Exception(error_msg)
 
     LOGGER.info(f'Deploying docker service as {docker.registry_opts}')
     docker.deploy()

--- a/enos/tasks/up.py
+++ b/enos/tasks/up.py
@@ -146,6 +146,7 @@ def up(env: elib.Environment,
         'kolla_internal_vip_address': env['config']['vip'],
         'influx_vip': env['config']['influx_vip'],
         'resultdir': str(env.env_name),
+        'docker_custom_config': mk_kolla_docker_custom_config(docker),
         'cwd':  os.getcwd()
     }
     kolla_globals_values.update(env['config'].get('kolla', {}))
@@ -236,6 +237,31 @@ def title(title: str) -> Dict[str, str]:
     "A title for an ansible yaml commands"
 
     return {"display_name": "enos up : " + title}
+
+
+def mk_kolla_docker_custom_config(docker: elib.Docker) -> Dict[str, Any]:
+    '''Docker daemon conf for kolla-ansible that reflects elib.Docker
+
+    Kolla-ansible overwrites the Docker daemon configuration that is setup by
+    enoslib.  This function makes a specific Docker custom config for
+    kolla-ansible that reflects enoslib setup.
+
+    See https://github.com/BeyondTheClouds/enos/issues/345
+
+    '''
+    docker_custom_config: Dict[str, Any] = {'debug': True}
+
+    if 'ip' in docker.registry_opts:
+        ip = docker.registry_opts["ip"]
+        port = docker.registry_opts["port"]
+        mirror = f"http://{ip}:{port}"
+
+        docker_custom_config.update({
+            'registry-mirrors': [mirror],
+            'insecure-registries': [mirror],
+        })
+
+    return docker_custom_config
 
 
 def build_rsc_with_inventory(


### PR DESCRIPTION
Kolla-ansible overwrites the Docker daemon configuration that is setup by enoslib.  This PR adds a specific Docker custom configuration for kolla-ansible that reflects enoslib setup.

Fix https://github.com/BeyondTheClouds/enos/issues/345