### PR TITLE
Bump sphinx to 4.5.0 and only update doc when pushing to master

### DIFF
--- a/.github/workflows/build-and-publish-doc.yml
+++ b/.github/workflows/build-and-publish-doc.yml
@@ -7,6 +7,9 @@ on:
       - 'docs/**'
       # ... or if we change the project version
       - 'pyproject.toml'
+    # Trigger only on master branch (avoids updating the doc in a pull request)
+    branches:
+      - master
   # Trigger manually from the "Actions" tab
   workflow_dispatch:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,9 +53,9 @@ mock = "^4.0.3"
 ddt = "^1.4.2"
 # doc
 GitPython = ">=2.1.5"
-Sphinx = "^3.5.3"
+Sphinx = "^4.5.0"
 sphinx-autobuild = "^2021.3.14"
-sphinx-rtd-theme = "^0.5.2"
+sphinx-rtd-theme = "^1.0.0"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]


### PR DESCRIPTION
This fix two issues when generating the doc:

- compatibility with Python 3.10: https://github.com/sphinx-doc/sphinx/issues/9512

- compatibility with Jinja 3.1.0 that renamed context filters: https://jinja.palletsprojects.com/en/3.1.x/changes/#version-3-1-0

In addtion, only build the doc when pushing to master. Otherwise, anybody opening a pull request could push anything to the official documentation.